### PR TITLE
fix: emit pic and tbl placeholder types

### DIFF
--- a/src/xml/text.ts
+++ b/src/xml/text.ts
@@ -723,6 +723,29 @@ export function genXmlNvPrExtLst (options?: ObjectOptions, extraExts: string[] =
 }
 
 /**
+ * Resolve a placeholder type to the ST_PlaceholderType token written on `p:ph@type`.
+ * ECMA-376 §4.4.1.33 / CT_Placeholder: `type` is `use="optional" default="obj"`
+ * (`standards/ecma/part-20_presentationml-reference-material-slides.txt`).
+ * Omitting the attribute is therefore the generic object placeholder, not a picture/table slot.
+ *
+ * `PlaceholderProps.type` is the OOXML token ('pic', 'tbl', …) while PLACEHOLDER_TYPES is keyed
+ * by friendly name ('image', 'table'). Accept both so `type: 'pic'` and `PLACEHOLDER_TYPES.image`
+ * emit `type="pic"`. Port of gitbrent/PptxGenJS#1526; the prior double lookup dropped pic/tbl.
+ * @param {string} type placeholder type as provided by the user
+ * @returns OOXML placeholder type, or an empty string when unrecognized
+ */
+function resolvePlaceholderType (type: string | undefined): string {
+	if (!type) return ''
+
+	// A) OOXML value ('pic'): the documented form of `PlaceholderProps.type`
+	const ooxmlTypes: string[] = Object.values(PLACEHOLDER_TYPES)
+	if (ooxmlTypes.includes(type)) return type
+
+	// B) Enum key ('image'): tolerated so untyped (JS) callers keep working
+	return PLACEHOLDER_TYPES[type as keyof typeof PLACEHOLDER_TYPES]?.toString() ?? ''
+}
+
+/**
  * Generate an XML Placeholder
  * @param {ISlideObject} placeholderObj
  * @param {ObjectOptions} extraOpts slide-object options (phTypeExt override)
@@ -732,12 +755,7 @@ export function genXmlPlaceholder (placeholderObj: ISlideObject | undefined, ext
 	if (!placeholderObj) return ''
 
 	const placeholderIdx = placeholderObj.options?._placeholderIdx ? placeholderObj.options._placeholderIdx : ''
-	const placeholderTyp = placeholderObj.options?._placeholderType ? placeholderObj.options._placeholderType : ''
-	// NOTE: accept both the friendly name ('image', 'table') and the OOXML code it maps to ('pic', 'tbl').
-	// The old code looked the mapped code back up in the enum, which only ever hit for the types whose
-	// name and code are identical - that is why picture/chart/table placeholders never got a `type` (issue #33).
-	const placeholderCodes: string[] = Object.values(PLACEHOLDER_TYPES)
-	const placeholderType: string = PLACEHOLDER_TYPES[placeholderTyp]?.toString() ?? (placeholderCodes.includes(placeholderTyp) ? placeholderTyp : '')
+	const placeholderType = resolvePlaceholderType(placeholderObj.options?._placeholderType)
 
 	const attrs =
 		`${placeholderIdx ? ' idx="' + placeholderIdx.toString() + '"' : ''}` +

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -470,6 +470,51 @@ test('#33: picture/chart/table placeholders emit their `p:ph` type on the layout
 	assert.ok(pic.includes(`<a:off x="${Math.round(0.5 * 914400)}"`), 'slide image did not inherit the placeholder position')
 })
 
+test('gitbrent#1526: p:ph@type accepts OOXML tokens and PLACEHOLDER_TYPES keys', async () => {
+	const pptx = new pptxgen()
+	pptx.defineSlideMaster({
+		title: 'PH_TYPE_MATRIX',
+		objects: [
+			{ placeholder: { options: { name: 'title', type: 'title', x: 0.5, y: 0.2, w: 3, h: 0.5 }, text: '' } },
+			{ placeholder: { options: { name: 'body', type: 'body', x: 3.5, y: 0.2, w: 3, h: 0.5 }, text: '' } },
+			{ placeholder: { options: { name: 'pic', type: 'pic', x: 0.5, y: 1, w: 3, h: 2 }, text: '' } },
+			{ placeholder: { options: { name: 'tbl', type: 'tbl', x: 3.5, y: 1, w: 3, h: 2 }, text: '' } },
+			{ placeholder: { options: { name: 'chart', type: 'chart', x: 6.5, y: 1, w: 3, h: 2 }, text: '' } },
+			{ placeholder: { options: { name: 'media', type: 'media', x: 0.5, y: 3.2, w: 3, h: 2 }, text: '' } },
+			{ placeholder: { options: { name: 'imageKey', type: 'image', x: 3.5, y: 3.2, w: 3, h: 2 } as never, text: '' } },
+			{ placeholder: { options: { name: 'tableKey', type: 'table', x: 6.5, y: 3.2, w: 3, h: 2 } as never, text: '' } },
+			{ placeholder: { options: { name: 'generic', x: 0.5, y: 5.4, w: 3, h: 1 } as never, text: '' } },
+			{ placeholder: { options: { name: 'unknown', type: 'not-a-type', x: 3.5, y: 5.4, w: 3, h: 1 } as never, text: '' } },
+		],
+	})
+	pptx.addSlide({ masterName: 'PH_TYPE_MATRIX' })
+
+	const zip = await writeZip(pptx)
+	const layouts = await Promise.all([1, 2].map(async num => await readPart(zip, `ppt/slideLayouts/slideLayout${num}.xml`)))
+	const layout = layouts.find(xml => xml.includes('PH_TYPE_MATRIX')) ?? ''
+	assert.ok(layout, 'missing PH_TYPE_MATRIX layout')
+
+	const ph = (idx: number): string => new RegExp(`<p:ph[^>]*idx="${idx}"[^>]*>`).exec(layout)?.[0] ?? ''
+	const expectType = (idx: number, type: string) => {
+		assert.match(ph(idx), new RegExp(`type="${type}"`), `idx ${idx} should emit type="${type}"`)
+	}
+	const expectNoType = (idx: number) => {
+		assert.doesNotMatch(ph(idx), /type=/, `idx ${idx} should omit type (ECMA-376 CT_Placeholder default=obj)`)
+		assert.match(ph(idx), /idx=/, `idx ${idx} placeholder missing`)
+	}
+
+	expectType(100, 'title')
+	expectType(101, 'body')
+	expectType(102, 'pic')
+	expectType(103, 'tbl')
+	expectType(104, 'chart')
+	expectType(105, 'media')
+	expectType(106, 'pic')
+	expectType(107, 'tbl')
+	expectNoType(108)
+	expectNoType(109)
+})
+
 test('#32: masters accept any shape type, tables and media', async () => {
 	const pptx = new pptxgen()
 	pptx.defineSlideMaster({


### PR DESCRIPTION
## Summary
- Port [gitbrent/PptxGenJS#1526](https://github.com/gitbrent/PptxGenJS/pull/1526) onto `src/xml/text.ts` (this fork no longer has `src/gen-xml.ts`).
- The runtime bug was already fixed as issue #33; this keeps a named `resolvePlaceholderType` that accepts both OOXML tokens (`pic`/`tbl`) and `PLACEHOLDER_TYPES` keys (`image`/`table`).
- ECMA-376 §4.4.1.33 / `CT_Placeholder` in `standards/ecma/part-20_presentationml-reference-material-slides.txt` declares `type` as `use=\"optional\" default=\"obj\"`. `pic` and `tbl` are valid `ST_PlaceholderType` values in `standards/ecma/part-21_presentationml-reference-material-animation.txt`. Omitting `type` is therefore a generic object placeholder, not a picture/table slot.

## Test plan
- [x] `bun test test/issues.test.ts --test-name-pattern \"1526|#33\"`
- [ ] Confirm an unfilled `type: 'pic'` master still emits `<p:ph ... type=\"pic\"/>` in `ppt/slideLayouts/slideLayoutN.xml`