### PR TITLE
fix: XML-escape fontFace values and reject malformed OMML fragments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "pptxgenjs-plus",
       "dependencies": {
         "@node-projects/jszip": "^4.2.1",
+        "@rgrove/parse-xml": "^4.2.3",
         "pako": "^3.0.1",
       },
       "devDependencies": {
@@ -23,7 +24,7 @@
     },
     "packages/pptxgenjs-jsx": {
       "name": "pptxgenjs-plus-jsx",
-      "version": "4.1.17",
+      "version": "4.1.18",
       "dependencies": {
         "pptxgenjs-plus": "file:../..",
       },
@@ -103,6 +104,8 @@
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
     "@node-projects/jszip": ["@node-projects/jszip@4.2.1", "", { "dependencies": { "@types/node": "^26.1.1", "pako": "^3.0.1" } }, "sha512-KuSM1ZNidyl9l9JVlAAVg+3Tk0WaB0V45wp0ZGVfXcWmxw+TuE7KuyTdLJJkOfXcPWfDBAyeyisOOzTLV4RpBw=="],
+
+    "@rgrove/parse-xml": ["@rgrove/parse-xml@4.2.3", "", {}, "sha512-Jhlb+0zYez1T1yXUQs3F1qAtFuJljBVNdy9TKmLDauAXkxsOXopKYOyQ5Wm6SvP3fycav0GviX4Y15WWhGetMw=="],
 
     "@rsbuild/core": ["@rsbuild/core@2.1.13", "", { "dependencies": { "@rspack/core": "~2.1.10", "@swc/helpers": "^0.5.23" }, "peerDependencies": { "core-js": ">= 3.0.0" }, "optionalPeers": ["core-js"], "bin": { "rsbuild": "bin/rsbuild.js" } }, "sha512-Z+6MzmjOio4+bFZQ24k+7ge/oNCOdXIunAssrswTNE8AIf6mcyXpJZevRXRiOEMZasRPA8VNyh+9JngQLg729Q=="],
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 	},
 	"dependencies": {
 		"@node-projects/jszip": "^4.2.1",
+		"@rgrove/parse-xml": "^4.2.3",
 		"pako": "^3.0.1"
 	},
 	"devDependencies": {

--- a/src/charts/axes.ts
+++ b/src/charts/axes.ts
@@ -82,7 +82,7 @@ export function makeCatAxis (opts: IChartOptsLib, axisId: string, valAxisId: str
 	strXml += '    <a:pPr>'
 	strXml += `      <a:defRPr sz="${Math.round((opts.catAxisLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.catAxisLabelFontBold ? 1 : 0}" i="${opts.catAxisLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">`
 	strXml += '      <a:solidFill>' + createColorElement(opts.catAxisLabelColor || DEF_FONT_COLOR) + '</a:solidFill>'
-	strXml += '      <a:latin typeface="' + (opts.catAxisLabelFontFace || 'Arial') + '"/>'
+	strXml += '      <a:latin typeface="' + (encodeXmlEntities(opts.catAxisLabelFontFace) || 'Arial') + '"/>'
 	strXml += '   </a:defRPr>'
 	strXml += '  </a:pPr>'
 	strXml += '  <a:endParaRPr lang="' + (opts.lang || 'en-US') + '"/>'
@@ -186,7 +186,7 @@ export function makeValAxis (opts: IChartOptsLib, valAxisId: string): string {
 	strXml += '    <a:pPr>'
 	strXml += `      <a:defRPr sz="${Math.round((opts.valAxisLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.valAxisLabelFontBold ? 1 : 0}" i="${opts.valAxisLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">`
 	strXml += '        <a:solidFill>' + createColorElement(opts.valAxisLabelColor || DEF_FONT_COLOR) + '</a:solidFill>'
-	strXml += '        <a:latin typeface="' + (opts.valAxisLabelFontFace || 'Arial') + '"/>'
+	strXml += '        <a:latin typeface="' + (encodeXmlEntities(opts.valAxisLabelFontFace) || 'Arial') + '"/>'
 	strXml += '      </a:defRPr>'
 	strXml += '    </a:pPr>'
 	strXml += '  <a:endParaRPr lang="' + (opts.lang || 'en-US') + '"/>'
@@ -263,7 +263,7 @@ export function makeSerAxis (opts: IChartOptsLib, axisId: string, valAxisId: str
 	strXml += '    <a:pPr>'
 	strXml += `    <a:defRPr sz="${Math.round((opts.serAxisLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.serAxisLabelFontBold ? '1' : '0'}" i="${opts.serAxisLabelFontItalic ? '1' : '0'}" u="none" strike="noStrike">`
 	strXml += `      <a:solidFill>${createColorElement(opts.serAxisLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
-	strXml += `      <a:latin typeface="${opts.serAxisLabelFontFace || 'Arial'}"/>`
+	strXml += `      <a:latin typeface="${encodeXmlEntities(opts.serAxisLabelFontFace) || 'Arial'}"/>`
 	strXml += '   </a:defRPr>'
 	strXml += '  </a:pPr>'
 	strXml += '  <a:endParaRPr lang="' + (opts.lang || 'en-US') + '"/>'

--- a/src/charts/title.ts
+++ b/src/charts/title.ts
@@ -41,13 +41,13 @@ export function genXmlTitle (opts: IChartPropsTitle, chartX?: number, chartY?: n
             ${align}
             <a:defRPr ${sizeAttr} b="${titleBold}" i="${titleItalic}" u="none" strike="noStrike">
               <a:solidFill>${createColorElement(opts.color || DEF_FONT_COLOR)}</a:solidFill>
-              <a:latin typeface="${opts.fontFace || 'Arial'}"/>
+              <a:latin typeface="${encodeXmlEntities(opts.fontFace) || 'Arial'}"/>
             </a:defRPr>
           </a:pPr>
           <a:r>
             <a:rPr ${sizeAttr} b="${titleBold}" i="${titleItalic}" u="none" strike="noStrike">
               <a:solidFill>${createColorElement(opts.color || DEF_FONT_COLOR)}</a:solidFill>
-              <a:latin typeface="${opts.fontFace || 'Arial'}"/>
+              <a:latin typeface="${encodeXmlEntities(opts.fontFace) || 'Arial'}"/>
             </a:rPr>
             <a:t>${encodeXmlEntities(opts.title) || ''}</a:t>
           </a:r>

--- a/src/charts/xml.ts
+++ b/src/charts/xml.ts
@@ -219,8 +219,8 @@ export function makeXmlCharts (rel: ISlideRelChart): string {
 				strXml += '    <a:pPr>'
 				strXml += rel.opts.legendFontSize ? `<a:defRPr sz="${Math.round(Number(rel.opts.legendFontSize) * 100)}">` : '<a:defRPr>'
 				if (rel.opts.legendColor) strXml += genXmlColorSelection(rel.opts.legendColor)
-				if (rel.opts.legendFontFace) strXml += '<a:latin typeface="' + rel.opts.legendFontFace + '"/>'
-				if (rel.opts.legendFontFace) strXml += '<a:cs    typeface="' + rel.opts.legendFontFace + '"/>'
+				if (rel.opts.legendFontFace) strXml += '<a:latin typeface="' + encodeXmlEntities(rel.opts.legendFontFace) + '"/>'
+				if (rel.opts.legendFontFace) strXml += '<a:cs    typeface="' + encodeXmlEntities(rel.opts.legendFontFace) + '"/>'
 				strXml += '      </a:defRPr>'
 				strXml += '    </a:pPr>'
 				strXml += '    <a:endParaRPr lang="en-US"/>'
@@ -279,7 +279,7 @@ function genXmlDataLabelDefRPr (opts: IChartOptsLib): string {
 	return (
 		`<a:defRPr sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">` +
 		`<a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>` +
-		`<a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>` +
+		`<a:latin typeface="${encodeXmlEntities(opts.dataLabelFontFace) || 'Arial'}"/>` +
 		'</a:defRPr>'
 	)
 }
@@ -294,7 +294,7 @@ function genXmlDataLabelRichText (text: string, opts: IChartOptsLib): string {
 	let xml = '<c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r>'
 	xml += `<a:rPr lang="${lang}" dirty="0" sz="${sz}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}">`
 	xml += `<a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
-	xml += `<a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+	xml += `<a:latin typeface="${encodeXmlEntities(opts.dataLabelFontFace) || 'Arial'}"/>`
 	xml += '</a:rPr>'
 	xml += `<a:t>${encodeXmlEntities(text)}</a:t>`
 	xml += '</a:r></a:p></c:rich></c:tx>'
@@ -509,7 +509,7 @@ function makeChartType (
 						(opts.dataLabelFontSize || DEF_FONT_SIZE) * 100
 					)}" u="none">`
 					strXml += `<a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
-					strXml += `<a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+					strXml += `<a:latin typeface="${encodeXmlEntities(opts.dataLabelFontFace) || 'Arial'}"/>`
 					strXml += '</a:defRPr></a:pPr></a:p></c:txPr>'
 					if (opts.dataLabelPosition) strXml += `<c:dLblPos val="${opts.dataLabelPosition}"/>`
 					strXml += '<c:showLegendKey val="0"/>'
@@ -656,7 +656,7 @@ function makeChartType (
 				strXml += '      <a:p><a:pPr>'
 				strXml += `        <a:defRPr b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}" strike="noStrike" sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" u="none">`
 				strXml += '          <a:solidFill>' + createColorElement(opts.dataLabelColor || DEF_FONT_COLOR) + '</a:solidFill>'
-				strXml += '          <a:latin typeface="' + (opts.dataLabelFontFace || 'Arial') + '"/>'
+				strXml += '          <a:latin typeface="' + (encodeXmlEntities(opts.dataLabelFontFace) || 'Arial') + '"/>'
 				strXml += '        </a:defRPr>'
 				strXml += '      </a:pPr></a:p>'
 				strXml += '    </c:txPr>'
@@ -972,7 +972,7 @@ function makeChartType (
 				strXml += '      <a:p><a:pPr>'
 				strXml += `        <a:defRPr b="${opts.dataLabelFontBold ? '1' : '0'}" i="${opts.dataLabelFontItalic ? '1' : '0'}" strike="noStrike" sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" u="none">`
 				strXml += '          <a:solidFill>' + createColorElement(opts.dataLabelColor || DEF_FONT_COLOR) + '</a:solidFill>'
-				strXml += '          <a:latin typeface="' + (opts.dataLabelFontFace || 'Arial') + '"/>'
+				strXml += '          <a:latin typeface="' + (encodeXmlEntities(opts.dataLabelFontFace) || 'Arial') + '"/>'
 				strXml += '        </a:defRPr>'
 				strXml += '      </a:pPr></a:p>'
 				strXml += '    </c:txPr>'
@@ -1121,7 +1121,7 @@ function makeChartType (
 					Math.round(opts.dataLabelFontSize || DEF_FONT_SIZE) * 100
 				)}" u="none">`
 				strXml += `<a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
-				strXml += `<a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+				strXml += `<a:latin typeface="${encodeXmlEntities(opts.dataLabelFontFace) || 'Arial'}"/>`
 				strXml += '</a:defRPr></a:pPr></a:p></c:txPr>'
 				if (opts.dataLabelPosition) strXml += `<c:dLblPos val="${opts.dataLabelPosition}"/>`
 				strXml += '<c:showLegendKey val="0"/>'
@@ -1221,7 +1221,7 @@ function makeChartType (
 			strXml += '      <a:p>'
 			strXml += '        <a:pPr>'
 			strXml += `          <a:defRPr sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.dataLabelFontBold ? '1' : '0'}" i="${opts.dataLabelFontItalic ? '1' : '0'}" u="none" strike="noStrike">`
-			strXml += `            <a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+			strXml += `            <a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:latin typeface="${encodeXmlEntities(opts.dataLabelFontFace) || 'Arial'}"/>`
 			strXml += '          </a:defRPr>'
 			strXml += '        </a:pPr>'
 			strXml += '      </a:p>'

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -259,6 +259,61 @@ export function encodeXmlEntities (xml: string | undefined): string {
 	return xml.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;')
 }
 
+// XML Name with optional namespace prefix (e.g. `m:oMath`, `xml:space`)
+const XML_NAME = String.raw`[A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?`
+// Opening/self-closing tag with quoted attributes, closing tag, or comment
+const XML_TAG_RE = new RegExp(
+	String.raw`^<(?:(/)\s*(${XML_NAME})\s*|(${XML_NAME})((?:\s+${XML_NAME}\s*=\s*(?:"[^<"]*"|'[^<']*'))*)\s*(/)?)>|^<!--[\s\S]*?-->`
+)
+// XML defines exactly five named entities; anything else must be numeric
+const XML_ENTITY_RE = /^&(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);/
+
+/** Index of the first invalid `&` (bad or unterminated entity reference), or -1. */
+function findInvalidEntity (text: string): number {
+	let amp = text.indexOf('&')
+	while (amp !== -1) {
+		if (!XML_ENTITY_RE.test(text.slice(amp))) return amp
+		amp = text.indexOf('&', amp + 1)
+	}
+	return -1
+}
+
+/**
+ * Check that a string is a well-formed XML fragment (balanced quoted-attribute
+ * tags, no raw `<`/`&` in character data). Used to reject caller-supplied
+ * markup (e.g. OMML) that would otherwise corrupt the package — PowerPoint
+ * shows a repair prompt (or refuses to open) for malformed slide XML.
+ * @param {string} xml - XML fragment to validate
+ * @returns {string | null} description of the first problem, or null when well-formed
+ */
+export function validateXmlFragment (xml: string): string | null {
+	const stack: string[] = []
+	let pos = 0
+	while (pos < xml.length) {
+		const lt = xml.indexOf('<', pos)
+		const text = xml.slice(pos, lt === -1 ? xml.length : lt)
+		const badAmp = findInvalidEntity(text)
+		if (badAmp !== -1) {
+			return `invalid entity reference at offset ${pos + badAmp} ("${xml.substr(pos + badAmp, 12)}")`
+		}
+		if (lt === -1) break
+		const match = XML_TAG_RE.exec(xml.slice(lt))
+		if (!match) return `malformed tag at offset ${lt} ("${xml.substr(lt, 20)}")`
+		const [full, isClose, closeName, openName, attrs, selfClose] = match
+		if (isClose) {
+			const expected = stack.pop()
+			if (expected !== closeName) return `mismatched closing tag </${closeName}> at offset ${lt} (expected ${expected ? `</${expected}>` : 'no closing tag'})`
+		} else if (openName) {
+			const badAttrAmp = findInvalidEntity(attrs ?? '')
+			if (badAttrAmp !== -1) return `invalid entity reference in attributes of <${openName}> at offset ${lt}`
+			if (!selfClose) stack.push(openName)
+		}
+		pos = lt + full.length
+	}
+	if (stack.length) return `unclosed tag <${stack[stack.length - 1]}>`
+	return null
+}
+
 /**
  * Convert inches into EMU
  * @param {number|string} inches - as string or number

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -2,6 +2,8 @@
  * PptxGenJS: Utility Methods
  */
 
+import { parseXml } from '@rgrove/parse-xml'
+
 import { EMU, REGEX_HEX_COLOR, DEF_FONT_COLOR, DEF_TEXT_GLOW, ONEPT, SchemeColor, SCHEME_COLORS } from './core-enums'
 import { PresLayout, TextGlowProps, PresSlide, SlideLayout, ShapeFillProps, Color, ShapeLineProps, Coord, ShadowProps, ShapeGradientProps, ShapePatternProps, ModifiedThemeColor, ThemeProps, HexColor } from './core-interfaces'
 
@@ -259,59 +261,22 @@ export function encodeXmlEntities (xml: string | undefined): string {
 	return xml.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;')
 }
 
-// XML Name with optional namespace prefix (e.g. `m:oMath`, `xml:space`)
-const XML_NAME = String.raw`[A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?`
-// Opening/self-closing tag with quoted attributes, closing tag, or comment
-const XML_TAG_RE = new RegExp(
-	String.raw`^<(?:(/)\s*(${XML_NAME})\s*|(${XML_NAME})((?:\s+${XML_NAME}\s*=\s*(?:"[^<"]*"|'[^<']*'))*)\s*(/)?)>|^<!--[\s\S]*?-->`
-)
-// XML defines exactly five named entities; anything else must be numeric
-const XML_ENTITY_RE = /^&(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);/
-
-/** Index of the first invalid `&` (bad or unterminated entity reference), or -1. */
-function findInvalidEntity (text: string): number {
-	let amp = text.indexOf('&')
-	while (amp !== -1) {
-		if (!XML_ENTITY_RE.test(text.slice(amp))) return amp
-		amp = text.indexOf('&', amp + 1)
-	}
-	return -1
-}
-
 /**
- * Check that a string is a well-formed XML fragment (balanced quoted-attribute
- * tags, no raw `<`/`&` in character data). Used to reject caller-supplied
- * markup (e.g. OMML) that would otherwise corrupt the package — PowerPoint
- * shows a repair prompt (or refuses to open) for malformed slide XML.
+ * Check that a string is a well-formed XML fragment (strict XML 1.0 via
+ * `@rgrove/parse-xml`). Used to reject caller-supplied markup (e.g. OMML)
+ * that would otherwise corrupt the package — PowerPoint shows a repair
+ * prompt (or refuses to open) for malformed slide XML.
  * @param {string} xml - XML fragment to validate
  * @returns {string | null} description of the first problem, or null when well-formed
  */
 export function validateXmlFragment (xml: string): string | null {
-	const stack: string[] = []
-	let pos = 0
-	while (pos < xml.length) {
-		const lt = xml.indexOf('<', pos)
-		const text = xml.slice(pos, lt === -1 ? xml.length : lt)
-		const badAmp = findInvalidEntity(text)
-		if (badAmp !== -1) {
-			return `invalid entity reference at offset ${pos + badAmp} ("${xml.substr(pos + badAmp, 12)}")`
-		}
-		if (lt === -1) break
-		const match = XML_TAG_RE.exec(xml.slice(lt))
-		if (!match) return `malformed tag at offset ${lt} ("${xml.substr(lt, 20)}")`
-		const [full, isClose, closeName, openName, attrs, selfClose] = match
-		if (isClose) {
-			const expected = stack.pop()
-			if (expected !== closeName) return `mismatched closing tag </${closeName}> at offset ${lt} (expected ${expected ? `</${expected}>` : 'no closing tag'})`
-		} else if (openName) {
-			const badAttrAmp = findInvalidEntity(attrs ?? '')
-			if (badAttrAmp !== -1) return `invalid entity reference in attributes of <${openName}> at offset ${lt}`
-			if (!selfClose) stack.push(openName)
-		}
-		pos = lt + full.length
+	try {
+		// Synthetic root: fragments may have multiple top-level elements
+		parseXml(`<x>${xml}</x>`)
+		return null
+	} catch (error) {
+		return (error as Error).message.split('\n')[0]
 	}
-	if (stack.length) return `unclosed tag <${stack[stack.length - 1]}>`
-	return null
 }
 
 /**

--- a/src/xml/text.ts
+++ b/src/xml/text.ts
@@ -40,6 +40,7 @@ import {
 	genXmlColorSelection,
 	inch2Emu,
 	resolveGlowOptions,
+	validateXmlFragment,
 	valToPts,
 	warnDeprecatedOnce,
 } from '../gen-utils'
@@ -233,9 +234,9 @@ function genXmlTextRunProperties (opts: ObjectOptions | TextPropsOptions, isDefa
 		const cs = opts.fontFaceCs || opts.fontFace
 		if (latin || ea || cs) {
 			// NOTE: 'cs' = Complex Script, 'ea' = East Asian (use "-120" instead of "0" - per Issue #174)
-			if (latin) runProps += `<a:latin typeface="${latin}" pitchFamily="34" charset="0"/>`
-			if (ea) runProps += `<a:ea typeface="${ea}" pitchFamily="34" charset="-122"/>`
-			if (cs) runProps += `<a:cs typeface="${cs}" pitchFamily="34" charset="-120"/>`
+			if (latin) runProps += `<a:latin typeface="${encodeXmlEntities(latin)}" pitchFamily="34" charset="0"/>`
+			if (ea) runProps += `<a:ea typeface="${encodeXmlEntities(ea)}" pitchFamily="34" charset="-122"/>`
+			if (cs) runProps += `<a:cs typeface="${encodeXmlEntities(cs)}" pitchFamily="34" charset="-120"/>`
 		}
 	}
 
@@ -289,6 +290,13 @@ export const P1710_NS = 'http://schemas.microsoft.com/office/powerpoint/2017/10/
 function normalizeOmml (omml: string): string {
 	let trimmed = omml.trim()
 	if (!trimmed) return ''
+
+	// Malformed OMML would be embedded verbatim and corrupt the whole package
+	// (PowerPoint repair prompt / open failure), so fail fast with a pointer.
+	const problem = validateXmlFragment(trimmed)
+	if (problem) {
+		throw new Error(`ERROR: text run 'omml' option is not a well-formed XML fragment: ${problem}. Escape all '<', '&' in math text (e.g. <m:t>a&lt;b</m:t>).`)
+	}
 
 	// Already PowerPoint-wrapped
 	if (/^<a14:m[\s/>]/i.test(trimmed)) return trimmed
@@ -656,9 +664,9 @@ export function genXmlTextBody (slideObj: ISlideObject | TableCell): string {
 			const cs = opts.fontFaceCs || opts.fontFace
 			if (latin || ea || cs) {
 				strSlideXml += `<a:endParaRPr lang="${opts.lang || 'en-US'}"` + (opts.fontSize ? ` sz="${Math.round(opts.fontSize * 100)}"` : '') + ' dirty="0">'
-				if (latin) strSlideXml += `<a:latin typeface="${latin}" charset="0"/>`
-				if (ea) strSlideXml += `<a:ea typeface="${ea}" charset="0"/>`
-				if (cs) strSlideXml += `<a:cs typeface="${cs}" charset="0"/>`
+				if (latin) strSlideXml += `<a:latin typeface="${encodeXmlEntities(latin)}" charset="0"/>`
+				if (ea) strSlideXml += `<a:ea typeface="${encodeXmlEntities(ea)}" charset="0"/>`
+				if (cs) strSlideXml += `<a:cs typeface="${encodeXmlEntities(cs)}" charset="0"/>`
 				strSlideXml += '</a:endParaRPr>'
 			} else {
 				strSlideXml += `<a:endParaRPr lang="${opts.lang || 'en-US'}"` + (opts.fontSize ? ` sz="${Math.round(opts.fontSize * 100)}"` : '') + ' dirty="0"/>'

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -3396,3 +3396,57 @@ test('fujita-h/7280811: ST_PlaceholderType tokens emit on p:ph@type', async () =
 	assert.ok(layout.includes('type="ftr"'), 'ftr missing')
 	assert.ok(layout.includes('type="sldNum"'), 'sldNum missing')
 })
+
+test('Escaping: fontFace with XML-special characters emits a well-formed typeface attribute', async () => {
+	// Real-world repair-dialog case: a consumer passed the literal string `&quot`
+	// as fontFace and the raw interpolation produced typeface="&quot" — a broken
+	// entity reference that makes PowerPoint refuse to open the file.
+	const pptx = new pptxgen()
+	pptx.addSlide().addText('body', { x: 0.5, y: 0.5, w: 4, h: 1, fontFace: '&quot' })
+	pptx.addSlide().addTable([[{ text: 'cell', options: { fontFace: 'A<B&"C' } }]], { x: 0.5, y: 0.5, w: 4 })
+
+	const zip = await writeZip(pptx)
+	await assertPptxPackageContracts(zip)
+	const slide1 = await readPart(zip, 'ppt/slides/slide1.xml')
+	assert.ok(slide1.includes('typeface="&amp;quot"'), 'fontFace ampersand was not XML-escaped in a:latin@typeface')
+	assert.ok(!/typeface="&quot[^;]/.test(slide1), 'broken entity reference leaked into typeface attribute')
+	const slide2 = await readPart(zip, 'ppt/slides/slide2.xml')
+	assert.ok(slide2.includes('typeface="A&lt;B&amp;&quot;C"'), 'table-cell fontFace was not XML-escaped')
+})
+
+test('Escaping: chart fontFace options with XML-special characters stay well-formed', async () => {
+	const evil = 'F&F<G'
+	const pptx = new pptxgen()
+	pptx.addSlide().addChart(pptx.ChartType.bar, [{ name: 'S', labels: ['Q1'], values: [1] }], {
+		x: 0.5, y: 0.5, w: 6, h: 3,
+		showTitle: true, title: 'T', titleFontFace: evil,
+		showValue: true, dataLabelFontFace: evil,
+		showLegend: true, legendFontFace: evil,
+		catAxisLabelFontFace: evil, valAxisLabelFontFace: evil,
+	})
+
+	const chart = await readChart(await writeZip(pptx))
+	assert.ok(!chart.includes(`typeface="${evil}"`), 'raw fontFace leaked into chart XML')
+	assert.ok(chart.includes('typeface="F&amp;F&lt;G"'), 'chart fontFace was not XML-escaped')
+})
+
+test('OMML: malformed omml option throws instead of writing a corrupt package', async () => {
+	// Unescaped '<'/'&' inside m:t (e.g. from a broken MathML->OMML converter)
+	// used to be embedded verbatim, producing a pptx PowerPoint cannot open.
+	const bad = '<m:oMath><m:r><m:t xml:space="preserve"><<br/>h</m:t></m:r></m:oMath>'
+	const pptx = new pptxgen()
+	pptx.addSlide().addText([{ text: '', options: { omml: bad } }], { x: 0.5, y: 0.5, w: 6, h: 1 })
+	await assert.rejects(async () => await pptx.write({ outputType: 'nodebuffer' }), /well-formed XML fragment/)
+
+	const badEntity = '<m:oMath><m:r><m:t>a&nbsp;b</m:t></m:r></m:oMath>'
+	const pptx2 = new pptxgen()
+	pptx2.addSlide().addText([{ text: '', options: { omml: badEntity } }], { x: 0.5, y: 0.5, w: 6, h: 1 })
+	await assert.rejects(async () => await pptx2.write({ outputType: 'nodebuffer' }), /well-formed XML fragment/)
+
+	// Valid OMML (incl. numeric refs + all five XML entities) must still pass
+	const good = '<m:oMath><m:r><m:t xml:space="preserve">a&lt;b&amp;c&#x200B;&quot;&apos;&gt;</m:t></m:r></m:oMath>'
+	const pptx3 = new pptxgen()
+	pptx3.addSlide().addText([{ text: '', options: { omml: good } }], { x: 0.5, y: 0.5, w: 6, h: 1 })
+	const xml = await readPart(await writeZip(pptx3), 'ppt/slides/slide1.xml')
+	assert.ok(xml.includes('a&lt;b&amp;c'), 'valid OMML was rejected or mangled')
+})


### PR DESCRIPTION
## Summary
- **fontFace escaping**: user-supplied `fontFace` / `fontFaceEa` / `fontFaceCs` and all chart font-face options (`titleFontFace`, `dataLabelFontFace`, `legendFontFace`, `catAxisLabelFontFace`, `valAxisLabelFontFace`, `serAxisLabelFontFace`) are now run through `encodeXmlEntities()` before landing in `typeface` attributes. A consumer passing the literal string `&quot` previously produced `typeface="&quot"` — a broken entity reference that makes PowerPoint show the repair dialog (or refuse the file entirely via COM).
- **OMML guard**: `normalizeOmml()` validates that the caller-supplied `omml` option is a well-formed XML fragment (new dependency-free `validateXmlFragment()` in `gen-utils`: balanced tags, quoted attributes, only the five XML named entities or numeric character refs). Malformed math (e.g. unescaped `<` inside `m:t` from a buggy MathML→OMML converter) now throws a descriptive error at write time instead of silently producing a corrupt package.

Root-caused from a real consumer deck ("Tlak a vztlak v kapalinách.pptx") that PowerPoint refused to open: slide13 contained both `typeface="&quot"` (missing semicolon) and `<m:t>< <br/>h</m:t>` (raw `<`). Bisected with `tools/powerpoint-verify` — making only slide13 well-formed flipped the verdict from reject/repair to ok. The converter-side escaping bug is fixed separately in the `mathml2omml-plus` fork.

## Test plan
- [x] `bun run lint` / `bun run typecheck` clean
- [x] `bun run test` — 274 pass, including 3 new regression tests (fontFace escaping in text + table + charts, OMML guard reject/accept)
- [x] e2e with `tools/powerpoint-verify`: deck rebuilt with the original bad inputs opens clean (verdict `ok`) in real PowerPoint 16