### PR TITLE
fix: strip Word-only m:br from OMML so PowerPoint can open the file

### DIFF
--- a/src/ms-pptx-profile.ts
+++ b/src/ms-pptx-profile.ts
@@ -482,8 +482,8 @@ const EXT: MsPptxExtension[] = [
 		choiceRequires: 'a14',
 		fallback: 'plain text run (down-level)',
 		api: 'addText({ text, omml }) / math runs',
-		packageContract: 'PowerPoint requires a14:m around m:oMath. Bare OMML is stripped on open. presentationPr MAY carry the a14:m ext URI.',
-		officeFixture: 'Proven via PowerPoint 16 COM (src/xml/text.ts). Semantic: OMML wrapped in a14:m.',
+		packageContract: 'PowerPoint requires a14:m around m:oMath. Bare OMML is stripped on open. m:br (Word math line-break) is stripped — PowerPoint rejects the package if it is present. presentationPr MAY carry the a14:m ext URI.',
+		officeFixture: 'Proven via PowerPoint 16 COM (src/xml/text.ts). Semantic: OMML wrapped in a14:m; no m:br.',
 		schema: '[MS-ODRAWXML] + ECMA-376 math',
 	},
 	{

--- a/src/xml/text.ts
+++ b/src/xml/text.ts
@@ -298,6 +298,8 @@ function normalizeOmml (omml: string): string {
 		throw new Error(`ERROR: text run 'omml' option is not a well-formed XML fragment: ${problem}. Escape all '<', '&' in math text (e.g. <m:t>a&lt;b</m:t>).`)
 	}
 
+	trimmed = stripPowerPointIllegalOmml(trimmed)
+
 	// Already PowerPoint-wrapped
 	if (/^<a14:m[\s/>]/i.test(trimmed)) return trimmed
 
@@ -309,6 +311,21 @@ function normalizeOmml (omml: string): string {
 	}
 
 	return `<a14:m xmlns:a14="${A14_NS}">${trimmed}</a14:m>`
+}
+
+/**
+ * PowerPoint's `a14:m` math zone is a subset of Word OMML. `m:br` is legal in
+ * Word (ECMA-376 §22.1.2.10, parent `m:r`) but PowerPoint refuses to open the
+ * package when it is present — even wrapped in `m:r` (COM 0x80020009).
+ * Confirmed with powerpoint-verify on a deck whose only difference was a
+ * MathML `mspace linebreak="newline"` converted to a bare `<m:br/>`.
+ */
+function stripPowerPointIllegalOmml (xml: string): string {
+	return xml
+		.replace(/<m:r>\s*<m:br\b[^>]*\/>\s*<\/m:r>/gi, '')
+		.replace(/<m:r>\s*<m:br\b[^>]*>\s*<\/m:br>\s*<\/m:r>/gi, '')
+		.replace(/<m:br\b[^>]*\/>/gi, '')
+		.replace(/<m:br\b[^>]*>\s*<\/m:br>/gi, '')
 }
 
 export function textRunsHaveOmml (text: TextProps[] | string | undefined): boolean {

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -3450,3 +3450,19 @@ test('OMML: malformed omml option throws instead of writing a corrupt package', 
 	const xml = await readPart(await writeZip(pptx3), 'ppt/slides/slide1.xml')
 	assert.ok(xml.includes('a&lt;b&amp;c'), 'valid OMML was rejected or mangled')
 })
+
+test('OMML: m:br is stripped so PowerPoint can open the package', async () => {
+	// Word-oriented converters (mathml2omml) emit m:br for mspace linebreak="newline".
+	// PowerPoint rejects the whole file if that element appears inside a14:m.
+	const withBareBr = '<m:oMath><m:br/><m:r><m:t>vecF</m:t></m:r></m:oMath>'
+	const withWrappedBr = '<m:oMath><m:r><m:br/></m:r><m:r><m:t>F</m:t></m:r></m:oMath>'
+	const pptx = new pptxgen()
+	pptx.addSlide().addText([
+		{ text: '', options: { omml: withBareBr } },
+		{ text: '', options: { omml: withWrappedBr } },
+	], { x: 0.5, y: 0.5, w: 6, h: 1 })
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide1.xml')
+	assert.ok(!xml.includes('<m:br'), 'm:br must not reach slide XML')
+	assert.ok(xml.includes('<m:t xml:space="preserve">vecF</m:t>') || xml.includes('<m:t>vecF</m:t>'), 'run after bare br was dropped')
+	assert.ok(xml.includes('<m:t xml:space="preserve">F</m:t>') || xml.includes('<m:t>F</m:t>'), 'run after wrapped br was dropped')
+})


### PR DESCRIPTION
PowerPoint's `a14:m` math zone rejects the package (COM `0x80020009`) when `m:br` is present — even inside `m:r`. Word-oriented converters emit that element for MathML `mspace linebreak="newline"`.

Confirmed with `powerpoint-verify` on `dynamika.pptx` slide 3: the only unique construct was a bare `<m:br/>` before `vecF`. Removing it turns `reject` into `ok`; wrapping it in `m:r` still rejects.

`normalizeOmml` now strips `m:br` (and empty `m:r` wrappers that only contained it) before embedding.