### PR TITLE
feat: add ChartEx chart types and opt-in chart style parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- PowerPoint 2016+ ChartEx types (`boxWhisker`, `funnel`, `histogram`, `sunburst`, `treemap`, `waterfall`) as native `cx:chart` parts; `addChart` accepts both `CHART_NAME` and `CHARTEX_NAME`
+- Opt-in chart style and chart colors parts (`cs:chartStyle`, `cs:colorStyle`) via `chartStyle` / `chartColorStyle`; ChartEx layouts always write them
 - Text `vertOverflow` / `horzOverflow` emit ECMA-376 `a:bodyPr` overflow attrs so overflowing runs can clip instead of spilling out of the shape
 - Package-contract tests for opt-in `addFont` (Font parts, `application/x-fontdata`, Presentation font rels); default export embeds nothing
 - `pptx.slideShow` emits a spec-valid `p:showPr` with the required present/browse/kiosk choice, plus loop/narration/animation/timing flags

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/pptxgenjs-jsx": {
       "name": "pptxgenjs-plus-jsx",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "dependencies": {
         "pptxgenjs-plus": "file:../..",
       },
@@ -35,14 +35,14 @@
     },
     "packages/pptxgenjs-std": {
       "name": "pptxgenjs-plus-std",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "devDependencies": {
         "@types/node": "^26.2.0",
         "pptxgenjs-plus": "file:../..",
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "pptxgenjs-plus": "4.1.19",
+        "pptxgenjs-plus": "4.1.20",
       },
     },
   },

--- a/src/charts/chartex.ts
+++ b/src/charts/chartex.ts
@@ -1,0 +1,234 @@
+/**
+ * ChartEx (`cx:chartSpace`) rendering - MS-ODRAWXML 2.1.
+ *
+ * PowerPoint 2016 introduced chart layouts that ECMA-376 has no markup for. They are written to their
+ * own part, in the `cx` namespace, and share nothing with the `c:` emitter in `xml.ts` beyond the
+ * embedded workbook: the data lives in `cx:chartData` (one `cx:data` per series) and the layout is
+ * selected by `cx:series@layoutId` rather than by the element name.
+ *
+ * The cell references point at the same worksheet `workbook.ts` writes for classic charts - column A
+ * holds the category labels, columns B.. hold one series each, row 1 holds the series names - so no
+ * chartex-specific workbook layout is needed.
+ */
+
+import { CHARTEX_LAYOUT_ID, CHARTEX_NAME, DEF_FONT_COLOR, DEF_FONT_SIZE, DEF_FONT_TITLE_SIZE, OOXML_CHARTEX, isChartexType } from '../core-enums'
+import { IChartOptsLib, IOptsChartData, ISlideRelChart } from '../core-interfaces'
+import { createColorElement, encodeXmlEntities, getUuid } from '../gen-utils'
+import { getExcelColName } from './utils'
+
+/** Sheet name written by `workbook.ts`; chartex cell references are absolute and always single-sheet */
+const SHEET = 'Sheet1'
+
+/**
+ * Category-axis gap width per layout, matching what PowerPoint writes for a freshly inserted chart.
+ * A layout absent here (treemap, sunburst) draws no axes at all.
+ */
+const CAT_GAP_WIDTH: Partial<Record<CHARTEX_NAME, string>> = { boxWhisker: '1', funnel: '0.0599999987', histogram: '0', waterfall: '0.5' }
+
+function firstLabelLevel (data: IOptsChartData[]): string[] {
+	const labels = data[0]?.labels
+	if (!labels || labels.length === 0) return []
+	const level = labels[0]
+	return Array.isArray(level) ? level : []
+}
+
+/**
+ * `<cx:pt idx="N">value</cx:pt>` for every point of one dimension
+ * - a missing point is written empty: `cx:pt` inside a `cx:numDim` must be a number, so the string
+ *   "null" would be a schema violation (the ECMA-376 emitter blanks the same case)
+ */
+function makePoints (values: Array<string | number | null | undefined>): string {
+	return values
+		.map((value, idx) => `<cx:pt idx="${idx}">${value === null || value === undefined ? '' : encodeXmlEntities(String(value))}</cx:pt>`)
+		.join('')
+}
+
+/**
+ * Absolute A1 reference for one column of the embedded worksheet, excluding the header row.
+ * The range length must equal the dimension's own `ptCount`, so each dimension passes its own.
+ */
+function columnRef (colIdx: number, pointCount: number): string {
+	const col = getExcelColName(colIdx)
+	return `${SHEET}!$${col}$2:$${col}$${pointCount + 1}`
+}
+
+/**
+ * One `cx:data` block per series.
+ * - hierarchical layouts (treemap, sunburst) size their segments through a `size` dimension
+ * - a histogram bins raw values itself, so it carries no category dimension at all
+ */
+function makeChartData (rel: ISlideRelChart, chartType: CHARTEX_NAME): string {
+	const labels = firstLabelLevel(rel.data)
+	const dimType = chartType === 'treemap' || chartType === 'sunburst' ? 'size' : 'val'
+
+	return rel.data
+		.map((series, seriesIdx) => {
+			const values = series.values ?? []
+			const catDim =
+				chartType === 'histogram' || labels.length === 0
+					? ''
+					: `<cx:strDim type="cat"><cx:f>${columnRef(1, labels.length)}</cx:f><cx:lvl ptCount="${labels.length}">${makePoints(labels)}</cx:lvl></cx:strDim>`
+			const valDim =
+				`<cx:numDim type="${dimType}"><cx:f>${columnRef(seriesIdx + 2, values.length)}</cx:f>` +
+				`<cx:lvl ptCount="${values.length}" formatCode="General">${makePoints(values)}</cx:lvl></cx:numDim>`
+
+			return `<cx:data id="${seriesIdx}">${catDim}${valDim}</cx:data>`
+		})
+		.join('')
+}
+
+/** `cx:dataLabels` - chartex has no `c:dLbls`, visibility is a single element with three flags */
+function makeDataLabels (opts: IChartOptsLib, chartType: CHARTEX_NAME): string {
+	const showValue = opts.showValue ?? false
+	const showCategory = opts.showLabel ?? false
+	if (!showValue && !showCategory) return ''
+
+	// `outEnd` is invalid on the layouts that draw labels inside their segments
+	const defaultPos = chartType === 'treemap' || chartType === 'sunburst' || chartType === 'funnel' ? 'ctr' : 'outEnd'
+	const pos = opts.dataLabelPosition ?? defaultPos
+	const size = Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)
+	const txPr =
+		'<cx:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr>' +
+		`<a:defRPr sz="${size}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}">` +
+		`<a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>` +
+		`<a:latin typeface="${encodeXmlEntities(opts.dataLabelFontFace || 'Arial')}"/>` +
+		'</a:defRPr></a:pPr></a:p></cx:txPr>'
+	const numFmt = opts.dataLabelFormatCode ? `<cx:numFmt formatCode="${encodeXmlEntities(opts.dataLabelFormatCode)}" sourceLinked="0"/>` : ''
+
+	return (
+		`<cx:dataLabels pos="${pos}">` +
+		`<cx:visibility seriesName="0" categoryName="${showCategory ? 1 : 0}" value="${showValue ? 1 : 0}"/>` +
+		numFmt +
+		txPr +
+		'</cx:dataLabels>'
+	)
+}
+
+/**
+ * `cx:layoutPr` carries everything that is layout-specific rather than series-generic.
+ * Anything absent here is left to PowerPoint's own default for that layout.
+ */
+function makeLayoutProps (opts: IChartOptsLib, chartType: CHARTEX_NAME): string {
+	switch (chartType) {
+		case 'waterfall': {
+			const subtotals = opts.chartExSubtotals ?? []
+			if (subtotals.length === 0) return ''
+			return `<cx:layoutPr><cx:subtotals>${subtotals.map(idx => `<cx:idx val="${idx}"/>`).join('')}</cx:subtotals></cx:layoutPr>`
+		}
+		case 'histogram': {
+			const binSize = opts.chartExBinSize
+			const binCount = opts.chartExBinCount
+			// PowerPoint accepts exactly one binning rule; an explicit size wins over a count, and neither
+			// means "let PowerPoint choose" (its automatic Scott's-rule binning)
+			const rule = binSize !== undefined ? `<cx:binSize val="${binSize}"/>` : binCount !== undefined ? `<cx:binCount val="${binCount}"/>` : ''
+			const binning = rule ? `<cx:binning intervalClosed="r">${rule}</cx:binning>` : '<cx:binning intervalClosed="r"/>'
+			return `<cx:layoutPr>${binning}</cx:layoutPr>`
+		}
+		case 'boxWhisker':
+			return (
+				'<cx:layoutPr>' +
+				`<cx:visibility meanLine="${opts.chartExMeanLine ? 1 : 0}" meanMarker="1" nonoutliers="0" outliers="1"/>` +
+				'<cx:statistics quartileMethod="exclusive"/>' +
+				'</cx:layoutPr>'
+			)
+		case 'treemap':
+			return `<cx:layoutPr><cx:parentLabelLayout val="${opts.chartExParentLabels ?? 'overlapping'}"/></cx:layoutPr>`
+		default:
+			return ''
+	}
+}
+
+/** One `cx:series` per data row. Order follows CT_Series: tx, spPr, dataLabels, dataId, layoutPr, axisId. */
+function makeSeries (rel: ISlideRelChart, chartType: CHARTEX_NAME): string {
+	const layoutId = CHARTEX_LAYOUT_ID[chartType]
+	const dataLabels = makeDataLabels(rel.opts, chartType)
+	const layoutPr = makeLayoutProps(rel.opts, chartType)
+
+	return rel.data
+		.map((series, idx) => {
+			const nameCell = `${SHEET}!$${getExcelColName(idx + 2)}$1`
+			// These layouts color each data point from the chart color style, so `chartColors` does not
+			// apply - a series-level fill would flatten a treemap to one color. Only `color` overrides it.
+			const spPr = series.color && series.color !== 'transparent' ? `<cx:spPr><a:solidFill>${createColorElement(series.color)}</a:solidFill></cx:spPr>` : ''
+
+			return (
+				`<cx:series layoutId="${layoutId}" uniqueId="{${getUuid('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx').toUpperCase()}}">` +
+				`<cx:tx><cx:txData><cx:f>${nameCell}</cx:f><cx:v>${encodeXmlEntities(series.name ?? `Series ${idx + 1}`)}</cx:v></cx:txData></cx:tx>` +
+				spPr +
+				dataLabels +
+				`<cx:dataId val="${idx}"/>` +
+				layoutPr +
+				'</cx:series>'
+			)
+		})
+		.join('')
+}
+
+/**
+ * `cx:axis` elements for the layouts that have axes. CT_Axis order: scaling, gridlines, tickLabels.
+ * - a funnel is drawn along a single category axis, which PowerPoint numbers `1`
+ * - treemap and sunburst have no axes; the series carries no `cx:axisId` in either case
+ */
+function makeAxes (rel: ISlideRelChart, chartType: CHARTEX_NAME): string {
+	const gapWidth = CAT_GAP_WIDTH[chartType]
+	if (gapWidth === undefined) return ''
+
+	if (chartType === 'funnel') return `<cx:axis id="1"><cx:catScaling gapWidth="${gapWidth}"/><cx:tickLabels/></cx:axis>`
+
+	const valGridlines = rel.opts.valGridLine?.style === 'none' ? '' : '<cx:majorGridlines/>'
+	return (
+		`<cx:axis id="0"><cx:catScaling gapWidth="${gapWidth}"/><cx:tickLabels/></cx:axis>` +
+		`<cx:axis id="1"><cx:valScaling/>${valGridlines}<cx:tickLabels/></cx:axis>`
+	)
+}
+
+function makeTitle (opts: IChartOptsLib): string {
+	if (!opts.showTitle) return ''
+	const size = Math.round((opts.titleFontSize || DEF_FONT_TITLE_SIZE) * 100)
+	const color = opts.titleColor ? `<a:solidFill>${createColorElement(opts.titleColor)}</a:solidFill>` : ''
+	const face = opts.titleFontFace ? `<a:latin typeface="${encodeXmlEntities(opts.titleFontFace)}"/>` : ''
+
+	return (
+		'<cx:title pos="t" align="ctr" overlay="0"><cx:tx><cx:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr algn="ctr"/><a:r>' +
+		`<a:rPr lang="${opts.lang || 'en-US'}" sz="${size}" b="${opts.titleBold ? 1 : 0}">${color}${face}</a:rPr>` +
+		`<a:t>${encodeXmlEntities(opts.title || 'Chart Title')}</a:t>` +
+		'</a:r></a:p></cx:rich></cx:tx></cx:title>'
+	)
+}
+
+function makeLegend (opts: IChartOptsLib): string {
+	if (!opts.showLegend) return ''
+	// `cx:legend@pos` takes l/r/t/b only; PowerPoint stores the library's `tr` as a top-aligned right legend
+	const isTopRight = opts.legendPos === 'tr'
+	return `<cx:legend pos="${isTopRight ? 'r' : opts.legendPos || 'r'}" align="${isTopRight ? 'min' : 'ctr'}" overlay="0"/>`
+}
+
+/**
+ * Build the `cx:chartSpace` part for one chartex chart.
+ * @param {ISlideRelChart} rel - chart relationship, with `opts._type` narrowed to a chartex type
+ * @returns {string} chartex part XML
+ */
+export function makeXmlChartEx (rel: ISlideRelChart): string {
+	const type = rel.opts._type
+	if (!isChartexType(type)) throw new Error(`pptxgenjs: "${String(type)}" is not a chartex chart type`)
+
+	return (
+		'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+		'<cx:chartSpace xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"' +
+		' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"' +
+		` xmlns:cx="${OOXML_CHARTEX.ns}">` +
+		'<cx:chartData>' +
+		'<cx:externalData r:id="rId1" cx:autoUpdate="0"/>' +
+		makeChartData(rel, type) +
+		'</cx:chartData>' +
+		'<cx:chart>' +
+		makeTitle(rel.opts) +
+		'<cx:plotArea>' +
+		`<cx:plotAreaRegion>${makeSeries(rel, type)}</cx:plotAreaRegion>` +
+		makeAxes(rel, type) +
+		'</cx:plotArea>' +
+		makeLegend(rel.opts) +
+		'</cx:chart>' +
+		'</cx:chartSpace>'
+	)
+}

--- a/src/charts/index.ts
+++ b/src/charts/index.ts
@@ -1,2 +1,4 @@
 export { createExcelWorksheet } from './workbook'
 export { makeXmlCharts } from './xml'
+export { makeXmlChartEx } from './chartex'
+export { chartColorsPartName, chartStylePartName, makeXmlChartColors, makeXmlChartStyle, wantsChartStyleParts } from './style'

--- a/src/charts/style.ts
+++ b/src/charts/style.ts
@@ -1,0 +1,101 @@
+/**
+ * Chart style and chart colour-style parts (`ppt/charts/styleN.xml`, `ppt/charts/colorsN.xml`).
+ *
+ * Classic `c:chart` parts write these only when `chartStyle` or `chartColorStyle` is set.
+ * ChartEx layouts always need both: PowerPoint resolves their visual properties through them.
+ *
+ * PowerPoint finds both parts by relationship type from the chart's own `.rels` - nothing inside
+ * `chartN.xml` points at them.
+ */
+import { CHART_STYLE, isChartexType } from '../core-enums'
+import { ChartColorStyleProps, IChartOptsLib } from '../core-interfaces'
+import { createColorElement } from '../gen-utils'
+
+const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+const NS_ATTRS = `xmlns:cs="${CHART_STYLE.ns}" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`
+
+/** The luminance variations Office writes for a six-colour cycling palette */
+const DEF_VARIATIONS = [
+	'',
+	'<a:lumMod val="60000"/>',
+	'<a:lumMod val="80000"/><a:lumOff val="20000"/>',
+	'<a:lumMod val="80000"/>',
+	'<a:lumMod val="60000"/><a:lumOff val="40000"/>',
+	'<a:lumMod val="50000"/>',
+	'<a:lumMod val="70000"/><a:lumOff val="30000"/>',
+	'<a:lumMod val="70000"/>',
+	'<a:lumMod val="50000"/><a:lumOff val="50000"/>',
+]
+
+/** The six theme accents, which is what Office's default colour style cycles through */
+const DEF_ACCENTS = ['accent1', 'accent2', 'accent3', 'accent4', 'accent5', 'accent6']
+
+/**
+ * Whether this chart should write `styleN.xml` / `colorsN.xml`.
+ * ChartEx always needs them; classic charts only write them when the caller opts in.
+ */
+export function wantsChartStyleParts (opts?: Pick<IChartOptsLib, '_type' | 'chartStyle' | 'chartColorStyle'>): boolean {
+	if (!opts) return false
+	if (isChartexType(opts._type)) return true
+	return opts.chartStyle !== undefined || opts.chartColorStyle !== undefined
+}
+
+/**
+ * Part name for a chart's colour style, matching the chart's own number
+ * @param {number} chartNum - the N in `chartN.xml`
+ * @returns {string} part name
+ */
+export function chartColorsPartName (chartNum: number): string {
+	return `ppt/charts/colors${chartNum}.xml`
+}
+
+/**
+ * Part name for a chart's style, matching the chart's own number
+ * @param {number} chartNum - the N in `chartN.xml`
+ * @returns {string} part name
+ */
+export function chartStylePartName (chartNum: number): string {
+	return `ppt/charts/style${chartNum}.xml`
+}
+
+/**
+ * Creates a chart's colour-style part (`cs:colorStyle`).
+ * @param {ChartColorStyleProps} [props] - colour style options
+ * @returns {string} XML
+ */
+export function makeXmlChartColors (props?: ChartColorStyleProps): string {
+	const methods = ['cycle', 'withinLinear', 'acrossLinear', 'withinLinearReversed', 'acrossLinearReversed']
+	const method = props?.method && methods.includes(props.method) ? props.method : 'cycle'
+	const id = typeof props?.id === 'number' && isFinite(props.id) && props.id > 0 ? Math.round(props.id) : 10
+	const colors = Array.isArray(props?.colors) && props.colors.length > 0
+		? props.colors.map(color => createColorElement(color)).join('')
+		: DEF_ACCENTS.map(accent => `<a:schemeClr val="${accent}"/>`).join('')
+
+	return (
+		`${XML_HEADER}<cs:colorStyle ${NS_ATTRS} meth="${method}" id="${id}">` +
+		colors +
+		DEF_VARIATIONS.map(variation => (variation ? `<cs:variation>${variation}</cs:variation>` : '<cs:variation/>')).join('') +
+		'</cs:colorStyle>'
+	)
+}
+
+/**
+ * Office's default chart style definitions, verbatim.
+ *
+ * The `@id` names which entry of PowerPoint's gallery is selected; the ~30 `cs:*` children are the
+ * definitions themselves. Only this one set is shipped - reproducing every gallery entry would mean
+ * ~150 more, none of which can be verified from a published schema.
+ */
+const DEF_CHART_STYLE = '<cs:chartStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" id="201"><cs:axisTitle><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:defRPr sz="1330" kern="1200"/></cs:axisTitle><cs:categoryAxis><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="15000"/><a:lumOff val="85000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr><cs:defRPr sz="1197" kern="1200"/></cs:categoryAxis><cs:chartArea mods="allowNoFillOverride allowNoLineOverride"><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="15000"/><a:lumOff val="85000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr><cs:defRPr sz="1330" kern="1200"/></cs:chartArea><cs:dataLabel><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="75000"/><a:lumOff val="25000"/></a:schemeClr></cs:fontRef><cs:defRPr sz="1197" kern="1200"/></cs:dataLabel><cs:dataLabelCallout><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="dk1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:spPr><a:solidFill><a:schemeClr val="lt1"/></a:solidFill><a:ln><a:solidFill><a:schemeClr val="dk1"><a:lumMod val="25000"/><a:lumOff val="75000"/></a:schemeClr></a:solidFill></a:ln></cs:spPr><cs:defRPr sz="1197" kern="1200"/><cs:bodyPr rot="0" spcFirstLastPara="1" vertOverflow="clip" horzOverflow="clip" vert="horz" wrap="square" lIns="36576" tIns="18288" rIns="36576" bIns="18288" anchor="ctr" anchorCtr="1"><a:spAutoFit/></cs:bodyPr></cs:dataLabelCallout><cs:dataPoint><cs:lnRef idx="0"/><cs:fillRef idx="1"><cs:styleClr val="auto"/></cs:fillRef><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef></cs:dataPoint><cs:dataPoint3D><cs:lnRef idx="0"/><cs:fillRef idx="1"><cs:styleClr val="auto"/></cs:fillRef><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef></cs:dataPoint3D><cs:dataPointLine><cs:lnRef idx="0"><cs:styleClr val="auto"/></cs:lnRef><cs:fillRef idx="1"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="28575" cap="rnd"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:round/></a:ln></cs:spPr></cs:dataPointLine><cs:dataPointMarker><cs:lnRef idx="0"><cs:styleClr val="auto"/></cs:lnRef><cs:fillRef idx="1"><cs:styleClr val="auto"/></cs:fillRef><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln></cs:spPr></cs:dataPointMarker><cs:dataPointMarkerLayout symbol="circle" size="5"/><cs:dataPointWireframe><cs:lnRef idx="0"><cs:styleClr val="auto"/></cs:lnRef><cs:fillRef idx="1"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="rnd"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:round/></a:ln></cs:spPr></cs:dataPointWireframe><cs:dataTable><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:spPr><a:noFill/><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="15000"/><a:lumOff val="85000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr><cs:defRPr sz="1197" kern="1200"/></cs:dataTable><cs:downBar><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="dk1"/></cs:fontRef><cs:spPr><a:solidFill><a:schemeClr val="dk1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></a:solidFill><a:ln w="9525"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></a:solidFill></a:ln></cs:spPr></cs:downBar><cs:dropLine><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="35000"/><a:lumOff val="65000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr></cs:dropLine><cs:errorBar><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr></cs:errorBar><cs:floor><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:noFill/><a:ln><a:noFill/></a:ln></cs:spPr></cs:floor><cs:gridlineMajor><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="15000"/><a:lumOff val="85000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr></cs:gridlineMajor><cs:gridlineMinor><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="5000"/><a:lumOff val="95000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr></cs:gridlineMinor><cs:hiLoLine><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="75000"/><a:lumOff val="25000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr></cs:hiLoLine><cs:leaderLine><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="35000"/><a:lumOff val="65000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr></cs:leaderLine><cs:legend><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:defRPr sz="1197" kern="1200"/></cs:legend><cs:plotArea mods="allowNoFillOverride allowNoLineOverride"><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef></cs:plotArea><cs:plotArea3D mods="allowNoFillOverride allowNoLineOverride"><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef></cs:plotArea3D><cs:seriesAxis><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:defRPr sz="1197" kern="1200"/></cs:seriesAxis><cs:seriesLine><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="35000"/><a:lumOff val="65000"/></a:schemeClr></a:solidFill><a:round/></a:ln></cs:spPr></cs:seriesLine><cs:title><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:defRPr sz="1862" b="0" kern="1200" spc="0" baseline="0"/></cs:title><cs:trendline><cs:lnRef idx="0"><cs:styleClr val="auto"/></cs:lnRef><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:ln w="19050" cap="rnd"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="sysDot"/></a:ln></cs:spPr></cs:trendline><cs:trendlineLabel><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:defRPr sz="1197" kern="1200"/></cs:trendlineLabel><cs:upBar><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="dk1"/></cs:fontRef><cs:spPr><a:solidFill><a:schemeClr val="lt1"/></a:solidFill><a:ln w="9525"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="15000"/><a:lumOff val="85000"/></a:schemeClr></a:solidFill></a:ln></cs:spPr></cs:upBar><cs:valueAxis><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"><a:lumMod val="65000"/><a:lumOff val="35000"/></a:schemeClr></cs:fontRef><cs:defRPr sz="1197" kern="1200"/></cs:valueAxis><cs:wall><cs:lnRef idx="0"/><cs:fillRef idx="0"/><cs:effectRef idx="0"/><cs:fontRef idx="minor"><a:schemeClr val="tx1"/></cs:fontRef><cs:spPr><a:noFill/><a:ln><a:noFill/></a:ln></cs:spPr></cs:wall></cs:chartStyle>'
+
+/**
+ * Creates a chart's style part (`cs:chartStyle`).
+ * @param {number} [styleId] - which gallery entry is selected; the definitions are Office's defaults
+ * @returns {string} XML
+ */
+export function makeXmlChartStyle (styleId?: number): string {
+	const body = typeof styleId === 'number' && isFinite(styleId) && styleId > 0
+		? DEF_CHART_STYLE.replace(/ id="\d+">/, ` id="${Math.round(styleId)}">`)
+		: DEF_CHART_STYLE
+	return XML_HEADER + body
+}

--- a/src/charts/workbook.ts
+++ b/src/charts/workbook.ts
@@ -1,9 +1,11 @@
 /** Embedded Excel workbook generation for charts. */
 
 import { JSZip } from '@node-projects/jszip'
-import { CHART_TYPE } from '../core-enums'
+import { CHART_STYLE, CHART_TYPE, isChartexType } from '../core-enums'
 import { ISlideRelChart } from '../core-interfaces'
 import { encodeXmlEntities } from '../gen-utils'
+import { makeXmlChartEx } from './chartex'
+import { chartColorsPartName, chartStylePartName, makeXmlChartColors, makeXmlChartStyle, wantsChartStyleParts } from './style'
 import { makeXmlCharts } from './xml'
 import { countErrorrateSeries, getExcelColName, seriesHasErrorrate } from './utils'
 
@@ -624,14 +626,28 @@ function addWorkbookToPresentation (chartObject: ISlideRelChart, zipExcel: JSZip
 				zip.file(`ppt/embeddings/Microsoft_Excel_Worksheet${chartObject.globalId}.xlsx`, content, { base64: true })
 
 				// 2: Create the chart.xml and rel files
+				// PowerPoint finds the style and colour-style parts by relationship type, so they are
+				// declared here rather than referenced from inside `chartN.xml`.
+				// Classic charts write them only when requested; ChartEx layouts always need them.
+				const isChartex = isChartexType(chartObject.opts._type)
+				const writeStyleParts = wantsChartStyleParts(chartObject.opts)
+				const styleRels = writeStyleParts
+					? `<Relationship Id="rId2" Type="${CHART_STYLE.colorsRelType}" Target="colors${chartObject.globalId}.xml"/>` +
+					`<Relationship Id="rId3" Type="${CHART_STYLE.styleRelType}" Target="style${chartObject.globalId}.xml"/>`
+					: ''
 				zip.file(
 					'ppt/charts/_rels/' + chartObject.fileName + '.rels',
 					'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
 					'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
 					`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/package" Target="../embeddings/Microsoft_Excel_Worksheet${chartObject.globalId}.xlsx"/>` +
+					styleRels +
 					'</Relationships>'
 				)
-				zip.file(`ppt/charts/${chartObject.fileName}`, makeXmlCharts(chartObject))
+				zip.file(`ppt/charts/${chartObject.fileName}`, isChartex ? makeXmlChartEx(chartObject) : makeXmlCharts(chartObject))
+				if (writeStyleParts) {
+					zip.file(chartColorsPartName(chartObject.globalId), makeXmlChartColors(chartObject.opts?.chartColorStyle))
+					zip.file(chartStylePartName(chartObject.globalId), makeXmlChartStyle(chartObject.opts?.chartStyle))
+				}
 
 				// 3: Done
 				resolve('')

--- a/src/charts/xml.ts
+++ b/src/charts/xml.ts
@@ -11,6 +11,7 @@ import {
 	BARCHART_COLORS,
 	CHART_NAME,
 	CHART_TYPE,
+	isChartexType,
 	DEF_FONT_COLOR,
 	DEF_FONT_SIZE,
 	DEF_FONT_TITLE_SIZE,
@@ -109,7 +110,7 @@ export function makeXmlCharts (rel: ISlideRelChart): string {
 			usesSecondaryValAxis = usesSecondaryValAxis || (options.secondaryValAxis ?? false)
 			strXml += makeChartType(type.type, type.data, options, valAxisId, catAxisId, true, rel.data)
 		})
-	} else if (rel.opts._type) {
+	} else if (rel.opts._type && !isChartexType(rel.opts._type)) {
 		strXml += makeChartType(rel.opts._type, rel.data, rel.opts, AXIS_ID_VALUE_PRIMARY, AXIS_ID_CATEGORY_PRIMARY, false, rel.data)
 	}
 

--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -40,7 +40,67 @@ export const AXIS_ID_SERIES_PRIMARY = '2094734556'
 export type JSZIP_OUTPUT_TYPE = 'arraybuffer' | 'base64' | 'binarystring' | 'blob' | 'nodebuffer' | 'uint8array'
 export type WRITE_OUTPUT_TYPE = JSZIP_OUTPUT_TYPE | 'STREAM'
 export type CHART_NAME = 'area' | 'bar' | 'bar3D' | 'bubble' | 'bubble3D' | 'doughnut' | 'line' | 'pie' | 'radar' | 'scatter'
+/** PowerPoint 2016+ chart types; emitted as a `cx:chartSpace` part (MS-ODRAWXML 2.1) rather than ECMA-376 `c:chartSpace` */
+export type CHARTEX_NAME = 'boxWhisker' | 'funnel' | 'histogram' | 'sunburst' | 'treemap' | 'waterfall'
 export type SCHEME_COLORS = 'tx1' | 'tx2' | 'bg1' | 'bg2' | 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
+
+/**
+ * Chart style and chart colour-style parts (MS-ODRAWXML)
+ * - verified against Microsoft's own `ChartStylePart`/`ChartColorStylePart` definitions in
+ *   dotnet/Open-XML-SDK, cross-checked against LibreOffice, rubyXL and OpenXLSX
+ * - note the asymmetry: the namespace is dated 2012, the relationships 2011. That is correct.
+ */
+export const CHART_STYLE = Object.freeze({
+	ns: 'http://schemas.microsoft.com/office/drawing/2012/chartStyle',
+	styleContentType: 'application/vnd.ms-office.chartstyle+xml',
+	colorsContentType: 'application/vnd.ms-office.chartcolorstyle+xml',
+	styleRelType: 'http://schemas.microsoft.com/office/2011/relationships/chartStyle',
+	colorsRelType: 'http://schemas.microsoft.com/office/2011/relationships/chartColorStyle',
+})
+
+/**
+ * ChartEx (PowerPoint 2016+) package contract - MS-ODRAWXML 2.1.
+ *
+ * These chart types have no ECMA-376 representation: they live in their own `cx:chartSpace` part with a
+ * Microsoft content type and relationship type, and the slide-level `p:graphicFrame` must sit inside an
+ * `mc:AlternateContent` so consumers that predate them still get a fallback.
+ *
+ * The `requires` namespace is the schema generation a consumer must understand before it may take the
+ * `mc:Choice`; funnel arrived a revision after the 2016 launch set, so it gates on a later one.
+ */
+export const OOXML_CHARTEX = {
+	/** `cx` - the chartex part's own namespace, and the `a:graphicData@uri` that identifies the frame */
+	ns: 'http://schemas.microsoft.com/office/drawing/2014/chartex',
+	partContentType: 'application/vnd.ms-office.chartex+xml',
+	relType: 'http://schemas.microsoft.com/office/2014/relationships/chartEx',
+	/** `mc:Choice@Requires` namespace for the Office 2016 launch layouts */
+	requires2016: 'http://schemas.microsoft.com/office/drawing/2015/9/8/chartex',
+	/** `mc:Choice@Requires` namespace for funnel, which shipped a schema revision later */
+	requiresFunnel: 'http://schemas.microsoft.com/office/drawing/2015/10/21/chartex',
+} as const
+
+/** `cx:series@layoutId` per chart type - a histogram is a `clusteredColumn` layout carrying `cx:binning` */
+export const CHARTEX_LAYOUT_ID: Record<CHARTEX_NAME, string> = {
+	boxWhisker: 'boxWhisker',
+	funnel: 'funnel',
+	histogram: 'clusteredColumn',
+	sunburst: 'sunburst',
+	treemap: 'treemap',
+	waterfall: 'waterfall',
+}
+
+/**
+ * `mc:Choice@Requires` namespace gating a chartex chart type
+ * - funnel arrived a schema revision after the 2016 launch layouts, so it gates on a later generation
+ */
+export function chartExRequiresNs (chartType: unknown): string {
+	return chartType === 'funnel' ? OOXML_CHARTEX.requiresFunnel : OOXML_CHARTEX.requires2016
+}
+
+/** True when `type` is emitted through the chartex pipeline rather than the ECMA-376 one */
+export function isChartexType (type: unknown): type is CHARTEX_NAME {
+	return typeof type === 'string' && Object.prototype.hasOwnProperty.call(CHARTEX_LAYOUT_ID, type)
+}
 
 /**
  * Slide transition type.
@@ -183,6 +243,12 @@ export enum ChartType {
 	'pie' = 'pie',
 	'radar' = 'radar',
 	'scatter' = 'scatter',
+	'boxWhisker' = 'boxWhisker',
+	'funnel' = 'funnel',
+	'histogram' = 'histogram',
+	'sunburst' = 'sunburst',
+	'treemap' = 'treemap',
+	'waterfall' = 'waterfall',
 }
 export enum ShapeType {
 	'accentBorderCallout1' = 'accentBorderCallout1',
@@ -784,13 +850,19 @@ export enum CHART_TYPE {
 	'AREA' = 'area',
 	'BAR' = 'bar',
 	'BAR3D' = 'bar3D',
+	'BOX_WHISKER' = 'boxWhisker',
 	'BUBBLE' = 'bubble',
 	'BUBBLE3D' = 'bubble3D',
 	'DOUGHNUT' = 'doughnut',
+	'FUNNEL' = 'funnel',
+	'HISTOGRAM' = 'histogram',
 	'LINE' = 'line',
 	'PIE' = 'pie',
 	'RADAR' = 'radar',
 	'SCATTER' = 'scatter',
+	'SUNBURST' = 'sunburst',
+	'TREEMAP' = 'treemap',
+	'WATERFALL' = 'waterfall',
 }
 
 export enum SCHEME_COLOR_NAMES {

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -3,7 +3,7 @@
  * PptxGenJS Interfaces
  */
 
-import { CHART_NAME, PLACEHOLDER_TYPE, SHAPE_NAME, SLIDE_OBJECT_TYPES, TEXT_HALIGN, TEXT_VALIGN, TRANSITION_TYPE, WRITE_OUTPUT_TYPE } from './core-enums'
+import { CHART_NAME, CHARTEX_NAME, PLACEHOLDER_TYPE, SHAPE_NAME, SLIDE_OBJECT_TYPES, TEXT_HALIGN, TEXT_VALIGN, TRANSITION_TYPE, WRITE_OUTPUT_TYPE } from './core-enums'
 
 // Core Types
 // ==========
@@ -2524,6 +2524,64 @@ export interface IChartPropsChartRadar {
 	 */
 	radarStyle?: 'standard' | 'marker' | 'filled' // TODO: convert to 'radar'|'markers'|'filled' in 4.0 (verbatim with PPT app UI)
 }
+/**
+ * Options for the PowerPoint 2016+ chartex layouts (waterfall, funnel, treemap, sunburst, histogram,
+ * box & whisker). Each is ignored by every other chart type.
+ * @see MS-ODRAWXML 2.1
+ */
+export interface IChartPropsChartEx {
+	/**
+	 * MS-PPT > Chart Type > Histogram > Format Axis > "Number of bins"
+	 * - fixed bin count; ignored when `chartExBinSize` is set
+	 * - omit both to let PowerPoint choose the bins
+	 * @example 8
+	 */
+	chartExBinCount?: number
+	/**
+	 * MS-PPT > Chart Type > Histogram > Format Axis > "Bin width"
+	 * - fixed bin width, in value-axis units; takes precedence over `chartExBinCount`
+	 * @example 5
+	 */
+	chartExBinSize?: number
+	/**
+	 * MS-PPT > Chart Type > Box & Whisker > Format Data Series > "Show mean line"
+	 * @default false
+	 */
+	chartExMeanLine?: boolean
+	/**
+	 * MS-PPT > Chart Type > Treemap > Format Data Series > "Treemap Label Options"
+	 * - how a parent category label is drawn over its children
+	 * @default overlapping
+	 */
+	chartExParentLabels?: 'none' | 'overlapping' | 'banner'
+	/**
+	 * MS-PPT > Chart Type > Waterfall > "Set as Total"
+	 * - zero-based indexes of the data points drawn as absolute totals rather than deltas
+	 * @example [0, 4] // first and fifth bars are totals
+	 */
+	chartExSubtotals?: number[]
+}
+/**
+ * Chart colour style (`cs:colorStyle` in `ppt/charts/colorsN.xml`)
+ * - the palette PowerPoint's Change Colors gallery offers for the chart
+ */
+export interface ChartColorStyleProps {
+	/**
+	 * How the palette is walked
+	 * @default cycle
+	 */
+	method?: 'cycle' | 'withinLinear' | 'acrossLinear' | 'withinLinearReversed' | 'acrossLinearReversed'
+	/**
+	 * Which entry of the Change Colors gallery is selected
+	 * @default 10
+	 */
+	id?: number
+	/**
+	 * The palette itself
+	 * @default the theme's six accent colours
+	 */
+	colors?: Color[]
+}
 export interface IChartPropsDataLabel {
 	dataLabelBkgrdColors?: boolean
 	dataLabelColor?: string
@@ -2595,6 +2653,7 @@ export interface IChartOpts
 	IChartPropsBase,
 	IChartPropsChartBar,
 	IChartPropsChartDoughnut,
+	IChartPropsChartEx,
 	IChartPropsChartLine,
 	IChartPropsChartPie,
 	IChartPropsChartRadar,
@@ -2611,6 +2670,20 @@ export interface IChartOpts
 	 */
 	altText?: string
 	/**
+	 * Which entry of PowerPoint's Chart Styles gallery is selected (`cs:chartStyle@id`)
+	 * - the style *definitions* written are Office's defaults regardless of this id, so it selects
+	 *   the gallery entry rather than changing the formatting
+	 * - opt-in for classic `c:chart` parts; ChartEx layouts always emit style/colors parts
+	 * @default 201
+	 */
+	chartStyle?: number
+	/**
+	 * Chart colour style (`ppt/charts/colorsN.xml`)
+	 * - distinct from `chartColors`, which sets the series colours directly on the chart
+	 * - opt-in for classic `c:chart` parts; ChartEx layouts always emit style/colors parts
+	 */
+	chartColorStyle?: ChartColorStyleProps
+	/**
 	 * Animation configuration
 	 * - Can be a simple animation name or full configuration object
 	 * @example 'fadein'
@@ -2623,10 +2696,10 @@ export interface IChartOpts
 	designPr?: DesignerProps
 }
 export interface IChartOptsLib extends IChartOpts {
-	_type?: CHART_NAME | IChartMulti[] // TODO: v3.4.0 - move to `IChartOpts`, remove `IChartOptsLib`
+	_type?: CHART_NAME | CHARTEX_NAME | IChartMulti[] // TODO: v3.4.0 - move to `IChartOpts`, remove `IChartOptsLib`
 }
 export interface ISlideRelChart extends OptsChartData {
-	type: CHART_NAME | IChartMulti[]
+	type: CHART_NAME | CHARTEX_NAME | IChartMulti[]
 	opts: IChartOptsLib
 	data: IOptsChartData[]
 	// internal below
@@ -2938,7 +3011,7 @@ export interface PresSlide extends SlideBaseProps {
 	_slideLayout: SlideLayout
 	_slideId: number
 
-	addChart: (type: CHART_NAME | IChartMulti[], data: IOptsChartData[], options?: IChartOpts) => PresSlide
+	addChart: (type: CHART_NAME | CHARTEX_NAME | IChartMulti[], data: IOptsChartData[], options?: IChartOpts) => PresSlide
 	addImage: (options: ImageProps) => PresSlide
 	addMedia: (options: MediaProps) => PresSlide
 	addNotes: (notes: string) => PresSlide

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -5,7 +5,9 @@
 import {
 	BARCHART_COLORS,
 	CHART_NAME,
+	CHARTEX_NAME,
 	CHART_TYPE,
+	isChartexType,
 	DEF_CELL_BORDER,
 	DEF_CELL_MARGIN_IN,
 	DEF_CHART_BORDER,
@@ -159,7 +161,7 @@ export function createSlideMaster(props: SlideMasterProps, target: SlideLayout):
  *    ]
  * }
  */
-export function addChartDefinition(target: PresSlide | SlideLayout, type: CHART_NAME | IChartMulti[], data: IOptsChartData[], opt: IChartOptsLib): object {
+export function addChartDefinition(target: PresSlide | SlideLayout, type: CHART_NAME | CHARTEX_NAME | IChartMulti[], data: IOptsChartData[], opt: IChartOptsLib): object {
 	function correctGridLineOptions(glOpts: OptsChartGridLine): void {
 		if (!glOpts || glOpts.style === 'none') return
 		if (glOpts.size !== undefined && (isNaN(Number(glOpts.size)) || glOpts.size <= 0)) {
@@ -189,6 +191,11 @@ export function addChartDefinition(target: PresSlide | SlideLayout, type: CHART_
 	let tmpOpt: IChartOptsLib | IOptsChartData[]
 	let tmpData: IOptsChartData[] = []
 	if (Array.isArray(type)) {
+		// A chartex layout owns the whole `cx:plotArea` and cannot share one with an ECMA-376 chart type,
+		// so a multi-type spec that names one would silently render as an empty frame
+		const chartexSpec = type.find(obj => isChartexType(obj.type))
+		if (chartexSpec) throw new Error(`pptxgenjs: chart type "${String(chartexSpec.type)}" cannot be combined in a multi-type chart`)
+
 		// For multi-type charts there needs to be data for each type,
 		// as well as a single data source for non-series operations.
 		// The data is indexed below to keep the data in order when segmented
@@ -266,8 +273,17 @@ export function addChartDefinition(target: PresSlide | SlideLayout, type: CHART_
 	// NOTE: a multi-type chart has no single type to validate against, so only the name translation applies there
 	if (options.dataLabelPosition) {
 		const chartType = Array.isArray(options._type) ? undefined : options._type
-		options.dataLabelPosition = resolveDataLabelPosition(options.dataLabelPosition, chartType, options.barGrouping) as typeof options.dataLabelPosition
-		if (!options.dataLabelPosition) delete options.dataLabelPosition
+		if (isChartexType(chartType)) {
+			// `cx:dataLabels@pos` is its own vocabulary, not `c:dLblPos`; these three are the values the
+			// shipped chartex writers emit, so anything else falls back to the layout's own default
+			if (!['ctr', 'inEnd', 'outEnd'].includes(options.dataLabelPosition)) {
+				console.warn(`[pptxgenjs] dataLabelPosition '${options.dataLabelPosition}' is not valid for a '${chartType}' chart - ignoring it (valid: ctr, inEnd, outEnd)`)
+				delete options.dataLabelPosition
+			}
+		} else {
+			options.dataLabelPosition = resolveDataLabelPosition(options.dataLabelPosition, chartType, options.barGrouping) as typeof options.dataLabelPosition
+			if (!options.dataLabelPosition) delete options.dataLabelPosition
+		}
 	}
 	options.dataLabelBkgrdColors = options.dataLabelBkgrdColors || !options.dataLabelBkgrdColors ? options.dataLabelBkgrdColors : false
 	if (!['b', 'l', 'r', 't', 'tr'].includes(options.legendPos || '')) options.legendPos = 'r'
@@ -396,6 +412,48 @@ export function addChartDefinition(target: PresSlide | SlideLayout, type: CHART_
 		delete options.catAxisMultiLevelLabels
 	}
 
+	// ChartEx: reject values PowerPoint would reject, so a bad option degrades to the layout default
+	// rather than to the repair dialog
+	if (isChartexType(options._type)) {
+		// Only box & whisker plots more than one distribution; the other layouts own the whole plot area
+		// and a second `cx:series` is either dropped or flagged for repair
+		if (options._type !== CHART_TYPE.BOX_WHISKER && tmpData.length > 1) {
+			console.warn(`Warning: a ${options._type} chart plots one series - ignoring ${tmpData.length - 1} extra series.`)
+			tmpData = tmpData.slice(0, 1)
+		}
+		tmpData.forEach(item => {
+			// ChartEx cell references assume one label column; the multi-level worksheet layout shifts the
+			// series columns right, so the extra levels are dropped rather than silently misaddressed
+			if (item.labels && item.labels.length > 1) {
+				console.warn('Warning: chartex charts take single-level category labels - using the first level.')
+				item.labels = [item.labels[0]]
+			}
+			// A histogram bins raw values and needs no categories, but the embedded worksheet still writes a
+			// row per label, so a label-less series is padded rather than left to fail during write()
+			const labels = item.labels?.[0]
+			if (!labels || labels.length === 0) item.labels = [Array<string>((item.values ?? []).length).fill('')]
+		})
+
+		const pointCount = Math.max(...tmpData.map(item => (item.values ?? []).length), 0)
+		if (options.chartExSubtotals) {
+			const valid = options.chartExSubtotals.filter(idx => Number.isInteger(idx) && idx >= 0 && idx < pointCount)
+			if (valid.length !== options.chartExSubtotals.length) console.warn(`Warning: chart.chartExSubtotals must be data point indexes 0-${pointCount - 1}.`)
+			options.chartExSubtotals = valid
+		}
+		if (options.chartExBinCount !== undefined && (!Number.isInteger(options.chartExBinCount) || options.chartExBinCount < 1)) {
+			console.warn('Warning: chart.chartExBinCount must be a positive integer.')
+			delete options.chartExBinCount
+		}
+		if (options.chartExBinSize !== undefined && (isNaN(options.chartExBinSize) || options.chartExBinSize <= 0)) {
+			console.warn('Warning: chart.chartExBinSize must be greater than 0.')
+			delete options.chartExBinSize
+		}
+		if (options.chartExParentLabels && !['none', 'overlapping', 'banner'].includes(options.chartExParentLabels)) {
+			console.warn('Warning: chart.chartExParentLabels options: `none`, `overlapping`, `banner`.')
+			delete options.chartExParentLabels
+		}
+	}
+
 	// STEP 4: Set props (_type already set to chart on the literal above).
 	// The chart object stores the position/placeholder that gen-xml reads; chart `fill`
 	// is a color string (vs ObjectOptions' ShapeFillProps) and is never read here, so it
@@ -411,14 +469,17 @@ export function addChartDefinition(target: PresSlide | SlideLayout, type: CHART_
 	resultObject.chartRid = getNewRelId(target)
 
 	// STEP 5: Add this chart to this Slide Rels (rId/rels count spans all slides! Count all images to get next rId)
+	// ChartEx charts are a separate part type with their own content type and relationship type,
+	// so the file name is what every downstream emitter keys off (see `xml/package.ts`)
+	const fileName = isChartexType(options._type) ? `chartEx${chartId}.xml` : `chart${chartId}.xml`
 	target._relsChart.push({
 		rId: getNewRelId(target),
 		data: tmpData,
 		opts: options,
 		type: options._type,
 		globalId: chartId,
-		fileName: `chart${chartId}.xml`,
-		Target: `/ppt/charts/chart${chartId}.xml`,
+		fileName,
+		Target: `/ppt/charts/${fileName}`,
 	})
 
 	target._slideObjects.push(resultObject)

--- a/src/slide.ts
+++ b/src/slide.ts
@@ -2,7 +2,7 @@
  * PptxGenJS: Slide Class
  */
 
-import { CHART_NAME, SHAPE_NAME } from './core-enums'
+import { CHART_NAME, CHARTEX_NAME, SHAPE_NAME } from './core-enums'
 import {
 	AddSlideProps,
 	AnimationConfig,
@@ -207,7 +207,7 @@ export default class Slide {
 	 * @param {IChartOpts} options - chart options
 	 * @return {Slide} this Slide
 	 */
-	addChart(type: CHART_NAME | IChartMulti[], data: IOptsChartData[], options?: IChartOpts): Slide {
+	addChart(type: CHART_NAME | CHARTEX_NAME | IChartMulti[], data: IOptsChartData[], options?: IChartOpts): Slide {
 		// FUTURE: TODO-VERSION-4: Remove first arg - only take data and opts, with "type" required on opts
 		genObj.addChartDefinition(this, type, Array.isArray(data) ? data.map(item => ({ ...item })) : data, cloneOpts(options))
 		return this

--- a/src/xml/package.ts
+++ b/src/xml/package.ts
@@ -2,12 +2,13 @@
  * OOXML package-part rendering.
  */
 
-import { CRLF, EMU, LAYOUT_IDX_SERIES_BASE, SLDNUMFLDID, SLIDE_OBJECT_TYPES } from '../core-enums'
+import { CHART_STYLE, CRLF, EMU, LAYOUT_IDX_SERIES_BASE, OOXML_CHARTEX, SLDNUMFLDID, SLIDE_OBJECT_TYPES, isChartexType } from '../core-enums'
 import {
 	AnimationConfig,
 	AnimationType,
 	GuideProps,
 	IPresentationProps,
+	ISlideRelChart,
 	PresSlide,
 	SectionProps,
 	SlideLayout,
@@ -16,6 +17,7 @@ import {
 	SlideShowProps,
 	TextProps,
 } from '../core-interfaces'
+import { chartColorsPartName, chartStylePartName, wantsChartStyleParts } from '../charts/style'
 import { createTimingXml, MediaPlaybackEntry } from '../gen-animations'
 import { genXmlTransition } from '../gen-transition'
 import { AUTHOR_PART_CONTENT_TYPE, AUTHOR_REL_TYPE, COMMENT_PART_CONTENT_TYPE, COMMENT_REL_URI, P188_NS } from '../gen-comments'
@@ -30,6 +32,21 @@ import {
 	REVISION_INFO_CONTENT_TYPE,
 	REVISION_INFO_REL_TYPE,
 } from '../gen-revision'
+
+/**
+ * Content-type overrides a chart needs: the chart itself plus, when requested, its style and colour-style parts.
+ * - one helper because charts appear on slides, layouts and the master, and a part with no declared
+ *   content type is a repair-dialog cause
+ */
+function chartContentTypes (rel: ISlideRelChart): string {
+	const partContentType = isChartexType(rel.opts._type) ? OOXML_CHARTEX.partContentType : 'application/vnd.openxmlformats-officedocument.drawingml.chart+xml'
+	let xml = `<Override PartName="${rel.Target}" ContentType="${partContentType}"/>`
+	if (wantsChartStyleParts(rel.opts)) {
+		xml += `<Override PartName="/${chartColorsPartName(rel.globalId)}" ContentType="${CHART_STYLE.colorsContentType}"/>`
+		xml += `<Override PartName="/${chartStylePartName(rel.globalId)}" ContentType="${CHART_STYLE.styleContentType}"/>`
+	}
+	return xml
+}
 
 /** Opt-in MS-PPTX presentation parts (zero-or-one each). */
 export type PresentationTrackingParts = {
@@ -138,7 +155,7 @@ export function makeXmlContTypes (slides: PresSlide[], slideLayouts: SlideLayout
 		strXml += `<Override PartName="/ppt/slides/slide${idx + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`
 		// Add charts if any
 		slide._relsChart.forEach(rel => {
-			strXml += `<Override PartName="${rel.Target}" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>`
+			strXml += chartContentTypes(rel)
 		})
 	})
 
@@ -153,7 +170,7 @@ export function makeXmlContTypes (slides: PresSlide[], slideLayouts: SlideLayout
 	slideLayouts.forEach((layout, idx) => {
 		strXml += `<Override PartName="/ppt/slideLayouts/slideLayout${idx + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>`
 		; (layout._relsChart || []).forEach(rel => {
-			strXml += ' <Override PartName="' + rel.Target + '" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>'
+			strXml += chartContentTypes(rel)
 		})
 	})
 
@@ -187,7 +204,7 @@ export function makeXmlContTypes (slides: PresSlide[], slideLayouts: SlideLayout
 
 	// STEP 6: Add rels
 	; (masterSlide?._relsChart ?? []).forEach(rel => {
-		strXml += ' <Override PartName="' + rel.Target + '" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>'
+		strXml += chartContentTypes(rel)
 	})
 	; (masterSlide?._relsMedia ?? []).forEach(rel => {
 		if (rel.type !== 'image' && rel.type !== 'online' && rel.type !== 'chart' && rel.extn !== 'm4v' && !strXml.includes(rel.type)) { strXml += ' <Default Extension="' + rel.extn + '" ContentType="' + rel.type + '"/>' }

--- a/src/xml/relationships.ts
+++ b/src/xml/relationships.ts
@@ -2,7 +2,7 @@
  * Relationship-part rendering.
  */
 
-import { CRLF, SLIDE_OBJECT_TYPES } from '../core-enums'
+import { CRLF, OOXML_CHARTEX, SLIDE_OBJECT_TYPES, isChartexType } from '../core-enums'
 import { COMMENT_REL_TYPE } from '../gen-comments'
 import { ISlideRel, ISlideRelChart, ISlideRelMedia, PresSlide, SlideLayout } from '../core-interfaces'
 import { REL_TYPE_CUSTOM_XML, REL_TYPE_WEBEXTENSION } from './content-parts'
@@ -42,7 +42,8 @@ function slideObjectRelationsToXml (slide: PresSlide | SlideLayout, defaultRels:
 		// is the absolute `/ppt/charts/chartN.xml` form reused as Content_Types PartName.
 		// PowerPoint writes the relative `../charts/chartN.xml`; absolute targets are valid but
 		// non-idiomatic and break stricter consumers (PR 1465 / eliasaronson).
-		strXml += `<Relationship Id="rId${rel.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="${rel.Target.replace(/^\/ppt\//, '../')}"/>`
+		const relType = isChartexType(rel.opts._type) ? OOXML_CHARTEX.relType : 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart'
+		strXml += `<Relationship Id="rId${rel.rId}" Type="${relType}" Target="${rel.Target.replace(/^\/ppt\//, '../')}"/>`
 	})
 	; (slide._relsMedia || []).forEach((rel: ISlideRelMedia) => {
 		const relRid = rel.rId.toString()

--- a/src/xml/slide.ts
+++ b/src/xml/slide.ts
@@ -8,13 +8,17 @@ import {
 	DEF_PRES_LAYOUT_NAME,
 	DEF_TEXT_SHADOW,
 	EMU,
+	OOXML_CHARTEX,
 	SHAPE_TYPE,
 	SLDNUMFLDID,
 	SLIDE_OBJECT_TYPES,
+	chartExRequiresNs,
+	isChartexType,
 } from '../core-enums'
 import {
 	BlurProps,
 	Coord,
+	IChartOptsLib,
 	ISlideObject,
 	ObjectOptions,
 	PresLayout,
@@ -45,7 +49,7 @@ import {
 import { getImagePixelSize } from '../gen-media'
 import { genXmlCreationIdExt, genXmlModIdExt, TABLE_MOD_ID_BASE } from '../gen-revision'
 import { genXmlContentPartAlternate, genXmlOfficeAppAlternate } from './content-parts'
-import { genXmlNvPrExtLst, genXmlPlaceholder, genXmlTextBody, textRunsHaveOmml } from './text'
+import { MC_NS, genXmlNvPrExtLst, genXmlPlaceholder, genXmlTextBody, textRunsHaveOmml } from './text'
 
 function nvPrModIdExt (modId?: number): string {
 	return genXmlModIdExt(modId).replace(/^<p:extLst>|<\/p:extLst>$/g, '')
@@ -53,6 +57,39 @@ function nvPrModIdExt (modId?: number): string {
 
 function genXmlNvPr (options?: ObjectOptions, phXml = '', extraExts: string[] = []): string {
 	return `<p:nvPr>${phXml}${genXmlNvPrExtLst(options, extraExts)}</p:nvPr>`
+}
+
+/**
+ * Fallback shape for a chartex graphic frame (`mc:Fallback`).
+ *
+ * PowerPoint writes a rendered preview picture here, which this library cannot produce without a
+ * rasterizer. A locked, non-editable text shape occupying the same box is the closest honest
+ * substitute: a consumer that rejects the `mc:Choice` still sees where the chart is and why it is
+ * not drawn, and cannot silently edit it into something that no longer matches the chart part.
+ */
+function genXmlChartExFallback (shapeId: number, slideItemObj: ISlideObject, box: { x: number, y: number, cx: number, cy: number }): string {
+	const options = slideItemObj.options ?? {}
+	const name = options.objectName ?? 'Chart'
+	const message = 'This chart is not available in your version of PowerPoint. Editing this shape or saving this file in a different format will permanently break the chart.'
+	// A chart's `title` is the chart title, not the alt-text title `p:cNvPr@title` carries.
+	// `noTextEdit` is not optional: an edited fallback would no longer match the chart part.
+
+	return (
+		'<p:sp>' +
+		'<p:nvSpPr>' +
+		`<p:cNvPr id="${shapeId}" name="${encodeXmlEntities(name)}" descr="${encodeXmlEntities(options.altText ?? message)}"/>` +
+		'<p:cNvSpPr><a:spLocks noTextEdit="1"/></p:cNvSpPr>' +
+		'<p:nvPr/>' +
+		'</p:nvSpPr>' +
+		`<p:spPr><a:xfrm><a:off x="${box.x}" y="${box.y}"/><a:ext cx="${box.cx}" cy="${box.cy}"/></a:xfrm>` +
+		'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>' +
+		'<a:solidFill><a:prstClr val="white"/></a:solidFill>' +
+		'<a:ln><a:solidFill><a:prstClr val="black"/></a:solidFill></a:ln></p:spPr>' +
+		'<p:txBody><a:bodyPr vertOverflow="clip" horzOverflow="clip" wrap="square"><a:normAutofit/></a:bodyPr><a:lstStyle/>' +
+		`<a:p><a:r><a:rPr lang="en-US" sz="1100"/><a:t>${encodeXmlEntities(message)}</a:t></a:r></a:p>` +
+		'</p:txBody>' +
+		'</p:sp>'
+	)
 }
 
 const ImageSizingXml = {
@@ -1153,21 +1190,42 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					break
 				}
 
-				case SLIDE_OBJECT_TYPES.chart:
-					strSlideXml += '<p:graphicFrame>'
-					strSlideXml += ' <p:nvGraphicFramePr>'
-					strSlideXml += `   <p:cNvPr id="${shapeId}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(slideItemObj.options.altText || '')}"/>`
-					strSlideXml += '   <p:cNvGraphicFramePr/>'
-					strSlideXml += genXmlNvPr(slideItemObj.options, genXmlPlaceholder(placeholderObj, slideItemObj.options), [nvPrModIdExt(slideItemObj.options.modId)])
-					strSlideXml += ' </p:nvGraphicFramePr>'
-					strSlideXml += ` <p:xfrm><a:off x="${x}" y="${y}"/><a:ext cx="${cx}" cy="${cy}"/></p:xfrm>`
-					strSlideXml += ' <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">'
-					strSlideXml += '  <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">'
-					strSlideXml += `   <c:chart r:id="rId${slideItemObj.chartRid}" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>`
-					strSlideXml += '  </a:graphicData>'
-					strSlideXml += ' </a:graphic>'
-					strSlideXml += '</p:graphicFrame>'
+				case SLIDE_OBJECT_TYPES.chart: {
+					const chartType = (slideItemObj.options as IChartOptsLib | undefined)?._type
+					const isChartex = isChartexType(chartType)
+					const graphicDataUri = isChartex ? OOXML_CHARTEX.ns : 'http://schemas.openxmlformats.org/drawingml/2006/chart'
+					const chartRef = isChartex
+						? `<cx:chart xmlns:cx="${OOXML_CHARTEX.ns}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId${slideItemObj.chartRid}"/>`
+						: `<c:chart r:id="rId${slideItemObj.chartRid}" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>`
+
+					let frameXml = '<p:graphicFrame>'
+					frameXml += ' <p:nvGraphicFramePr>'
+					frameXml += `   <p:cNvPr id="${shapeId}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(slideItemObj.options.altText || '')}"/>`
+					frameXml += '   <p:cNvGraphicFramePr/>'
+					frameXml += genXmlNvPr(slideItemObj.options, genXmlPlaceholder(placeholderObj, slideItemObj.options), [nvPrModIdExt(slideItemObj.options.modId)])
+					frameXml += ' </p:nvGraphicFramePr>'
+					frameXml += ` <p:xfrm><a:off x="${x}" y="${y}"/><a:ext cx="${cx}" cy="${cy}"/></p:xfrm>`
+					frameXml += ' <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">'
+					frameXml += `  <a:graphicData uri="${graphicDataUri}">`
+					frameXml += `   ${chartRef}`
+					frameXml += '  </a:graphicData>'
+					frameXml += ' </a:graphic>'
+					frameXml += '</p:graphicFrame>'
+
+					// A chartex frame replaces a standard graphic frame, so MS-PPTX 2.2 requires it be offered
+					// through `mc:AlternateContent`. PowerPoint's own fallback is a rendered preview image, which
+					// cannot be produced here - a locked text shape carrying the same message is the honest
+					// equivalent for a consumer that does not understand the chartex namespace.
+					strSlideXml += isChartex
+						? `<mc:AlternateContent xmlns:mc="${MC_NS}">` +
+							`<mc:Choice xmlns:cx1="${chartExRequiresNs(chartType)}" Requires="cx1">` +
+							frameXml +
+							'</mc:Choice>' +
+							`<mc:Fallback>${genXmlChartExFallback(shapeId, slideItemObj, { x, y, cx, cy })}</mc:Fallback>` +
+							'</mc:AlternateContent>'
+						: frameXml
 					break
+				}
 
 				case SLIDE_OBJECT_TYPES.group: {
 				// PresentationML `p:grpSp` (ECMA-376 §19.3.1.22): nvGrpSpPr + grpSpPr + children.

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -260,3 +260,226 @@ test('contract: rejects a comments part without a slide relationship', async () 
 	)
 	await assert.rejects(assertModernCommentPartContracts(invalidZip), /MUST be the target of an explicit relationship/)
 })
+
+// ChartEx (PowerPoint 2016+) charts - MS-ODRAWXML 2.1
+// The package contract is what makes or breaks these: a wrong content type, relationship type, or a
+// missing sidecar part makes PowerPoint declare the file damaged rather than degrade gracefully.
+
+/** Chart part ids are global to the process, so the part name is discovered rather than assumed */
+async function buildChartEx (type: string, data: object[], opts: object = {}): Promise<{ zip: JSZip, part: string }> {
+	const pptx = new pptxgen()
+	pptx.addSlide().addChart(type as never, data as never, { x: 0.5, y: 0.5, w: 6, h: 4, ...opts })
+	const zip = await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer)
+	const part = Object.keys(zip.files).find(name => /^ppt\/charts\/chartEx\d+\.xml$/.test(name)) ?? ''
+	return { zip, part }
+}
+
+/** The chartex part XML for one chart, asserting the part exists under a chartEx name */
+async function chartExXml (type: string, data: object[], opts: object = {}): Promise<string> {
+	const { zip, part } = await buildChartEx(type, data, opts)
+	assert.ok(part, `${type}: chartex parts are named chartExN.xml, not chartN.xml`)
+	return await readPart(zip, part)
+}
+
+const WATERFALL_DATA = [{ name: 'Cash', labels: ['Start', 'Q1', 'Q2', 'End'], values: [100, 30, -20, 110] }]
+
+test('contract: a chartex chart is a separate part with its own content and relationship types', async () => {
+	const { zip: cxZip, part } = await buildChartEx('waterfall', WATERFALL_DATA)
+	await assertPptxPackageContracts(cxZip)
+	await assertEmbeddedXlsxContracts(cxZip)
+
+	assert.ok(part, 'chartex parts are named chartExN.xml, not chartN.xml')
+	assert.equal(Object.keys(cxZip.files).filter(name => /^ppt\/charts\/chart\d+\.xml$/.test(name)).length, 0, 'a chartex chart must not also write an ECMA-376 chart part')
+
+	const contentTypes = await readPart(cxZip, '[Content_Types].xml')
+	assert.match(contentTypes, new RegExp(`PartName="/${part}" ContentType="application/vnd\\.ms-office\\.chartex\\+xml"`), 'chartex content type missing')
+
+	const rels = await readPart(cxZip, 'ppt/slides/_rels/slide1.xml.rels')
+	assert.match(rels, /Type="http:\/\/schemas\.microsoft\.com\/office\/2014\/relationships\/chartEx" Target="\.\.\/charts\/chartEx\d+\.xml"/, 'chartex relationship type missing')
+	assert.doesNotMatch(rels, /relationships\/chart"/, 'a chartex part must not use the ECMA-376 chart relationship type')
+})
+
+test('contract: a chartex chart relates to the style and color parts PowerPoint requires', async () => {
+	const { zip: cxZip, part } = await buildChartEx('treemap', [{ name: 'Revenue', labels: ['A', 'B', 'C'], values: [10, 20, 30] }])
+
+	const chartRels = await readPart(cxZip, `ppt/charts/_rels/${part.split('/').pop() ?? ''}.rels`)
+	const styleRel = /Type="http:\/\/schemas\.microsoft\.com\/office\/2011\/relationships\/chartStyle" Target="(style\d+\.xml)"/.exec(chartRels)
+	const colorsRel = /Type="http:\/\/schemas\.microsoft\.com\/office\/2011\/relationships\/chartColorStyle" Target="(colors\d+\.xml)"/.exec(chartRels)
+	assert.ok(styleRel, 'chart style relationship missing')
+	assert.ok(colorsRel, 'chart color style relationship missing')
+	assert.match(chartRels, /Id="rId1" Type="[^"]*relationships\/package"/, 'the embedded workbook must stay rId1')
+
+	const contentTypes = await readPart(cxZip, '[Content_Types].xml')
+	assert.match(contentTypes, new RegExp(`/ppt/charts/${styleRel[1]}" ContentType="application/vnd\\.ms-office\\.chartstyle\\+xml"`), 'chart style content type missing')
+	assert.match(contentTypes, new RegExp(`/ppt/charts/${colorsRel[1]}" ContentType="application/vnd\\.ms-office\\.chartcolorstyle\\+xml"`), 'chart color style content type missing')
+	assert.match(await readPart(cxZip, `ppt/charts/${styleRel[1]}`), /^<\?xml[^>]*\?><cs:chartStyle /, 'chart style part is not a cs:chartStyle document')
+	assert.match(await readPart(cxZip, `ppt/charts/${colorsRel[1]}`), /^<\?xml[^>]*\?><cs:colorStyle /, 'chart color style part is not a cs:colorStyle document')
+})
+
+test('contract: a chartex frame is offered through mc:AlternateContent with a fallback', async () => {
+	const { zip: cxZip } = await buildChartEx('waterfall', WATERFALL_DATA)
+	const slideXml = await readPart(cxZip, 'ppt/slides/slide1.xml')
+
+	const block = slideXml.slice(slideXml.indexOf('<mc:AlternateContent'), slideXml.indexOf('</mc:AlternateContent>'))
+	assert.ok(block, 'a chartex frame must be wrapped in mc:AlternateContent')
+	assert.match(block, /<mc:Choice xmlns:cx1="http:\/\/schemas\.microsoft\.com\/office\/drawing\/2015\/9\/8\/chartex" Requires="cx1">/, 'chartex Choice condition missing')
+	assert.match(block, /<a:graphicData uri="http:\/\/schemas\.microsoft\.com\/office\/drawing\/2014\/chartex">\s*<cx:chart [^>]*r:id="rId\d+"\/>/, 'chartex graphicData uri or chart reference missing')
+	assert.match(block, /<mc:Fallback><p:sp>/, 'a chartex frame must offer a fallback shape')
+	assert.match(block, /<a:spLocks noTextEdit="1"\/>/, 'the fallback must not be editable into something that no longer matches the chart')
+
+	const funnelXml = await readPart((await buildChartEx('funnel', [{ name: 'Pipeline', labels: ['Leads', 'Won'], values: [500, 30] }])).zip, 'ppt/slides/slide1.xml')
+	assert.match(funnelXml, /xmlns:cx1="http:\/\/schemas\.microsoft\.com\/office\/drawing\/2015\/10\/21\/chartex"/, 'funnel must require its own chartex generation')
+})
+
+test('contract: each chartex layout emits the markup PowerPoint keys off', async () => {
+	const waterfall = await chartExXml('waterfall', WATERFALL_DATA, { chartExSubtotals: [0, 3] })
+	assert.match(waterfall, /<cx:series layoutId="waterfall" uniqueId="\{[0-9A-F-]{36}\}">/, 'waterfall layoutId or uniqueId missing')
+	assert.match(waterfall, /<cx:subtotals><cx:idx val="0"\/><cx:idx val="3"\/><\/cx:subtotals>/, 'waterfall subtotals missing')
+	assert.match(waterfall, /<cx:strDim type="cat"><cx:f>Sheet1!\$A\$2:\$A\$5<\/cx:f>/, 'category dimension does not point at the worksheet label column')
+	assert.match(waterfall, /<cx:numDim type="val"><cx:f>Sheet1!\$B\$2:\$B\$5<\/cx:f>/, 'value dimension does not point at the worksheet series column')
+	assert.match(waterfall, /<cx:axis id="0"><cx:catScaling gapWidth="0\.5"\/>.*<cx:axis id="1"><cx:valScaling\/>/s, 'waterfall axes missing')
+
+	const histogram = await chartExXml('histogram', [{ name: 'Ages', labels: ['a', 'b', 'c'], values: [3, 7, 12] }], { chartExBinCount: 4 })
+	assert.match(histogram, /<cx:series layoutId="clusteredColumn"/, 'histogram layoutId missing')
+	assert.match(histogram, /<cx:binning intervalClosed="r"><cx:binCount val="4"\/><\/cx:binning>/, 'histogram bin count missing')
+	assert.doesNotMatch(histogram, /<cx:strDim type="cat"/, 'a histogram bins raw values and has no category dimension')
+
+	const treemap = await chartExXml('treemap', [{ name: 'Revenue', labels: ['A', 'B'], values: [10, 20] }], { chartExParentLabels: 'banner' })
+	assert.match(treemap, /<cx:numDim type="size">/, 'treemap must size segments through a size dimension')
+	assert.match(treemap, /<cx:parentLabelLayout val="banner"\/>/, 'treemap parent label layout missing')
+	assert.doesNotMatch(treemap, /<cx:axis /, 'a treemap has no axes')
+
+	const sunburst = await chartExXml('sunburst', [{ name: 'Revenue', labels: ['A', 'B'], values: [10, 20] }])
+	assert.match(sunburst, /<cx:series layoutId="sunburst"/, 'sunburst layoutId missing')
+
+	const box = await chartExXml('boxWhisker', [
+		{ name: 'A', labels: ['x', 'y'], values: [1, 5] },
+		{ name: 'B', labels: ['x', 'y'], values: [2, 6] },
+	], { chartExMeanLine: true })
+	assert.match(box, /<cx:data id="0">.*<cx:data id="1">/s, 'box & whisker needs one data block per series')
+	assert.match(box, /<cx:numDim type="val"><cx:f>Sheet1!\$C\$2:\$C\$3<\/cx:f>/, 'the second series must read the second worksheet column')
+	assert.match(box, /<cx:dataId val="1"\/>/, 'the second series must name its own data block')
+	assert.match(box, /<cx:visibility meanLine="1" meanMarker="1" nonoutliers="0" outliers="1"\/>/, 'box & whisker visibility missing')
+	assert.match(box, /<cx:statistics quartileMethod="exclusive"\/>/, 'box & whisker quartile method missing')
+
+	const funnel = await chartExXml('funnel', [{ name: 'Pipeline', labels: ['Leads', 'Won'], values: [500, 30] }])
+	assert.match(funnel, /<cx:axis id="1"><cx:catScaling/, 'funnel category axis missing')
+	assert.doesNotMatch(funnel, /<cx:axis id="0"/, 'a funnel has no value axis')
+})
+
+test('contract: chartex options that PowerPoint would reject are dropped with a warning', async () => {
+	const warnings: string[] = []
+	const origWarn = console.warn
+	let xml = ''
+	try {
+		console.warn = (msg: string) => warnings.push(String(msg))
+		xml = await chartExXml('waterfall', WATERFALL_DATA, { chartExSubtotals: [0, 9], chartExBinCount: 0, chartExParentLabels: 'sideways' })
+	} finally {
+		console.warn = origWarn
+	}
+
+	assert.equal(warnings.length, 3, `expected one warning per rejected option, got: ${warnings.join(' | ')}`)
+	assert.match(xml, /<cx:subtotals><cx:idx val="0"\/><\/cx:subtotals>/, 'the valid subtotal index must survive')
+	assert.doesNotMatch(xml, /val="9"/, 'an out-of-range subtotal index must not be emitted')
+})
+
+test('contract: a chartex type cannot be smuggled into a multi-type chart', () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	assert.throws(
+		() => slide.addChart([
+			{ type: 'bar' as never, data: [{ name: 'A', labels: ['x'], values: [1] }], options: {} },
+			{ type: 'waterfall' as never, data: [{ name: 'B', labels: ['x'], values: [2] }], options: {} },
+		], []),
+		/waterfall.*multi-type/,
+		'a chartex layout owns the whole plot area and cannot share one'
+	)
+})
+
+test('contract: classic charts are untouched by the chartex path', async () => {
+	const pptx = new pptxgen()
+	pptx.addSlide().addChart(pptx.ChartType.bar, [{ name: 'Sales', labels: ['Q1', 'Q2'], values: [10, 20] }], { x: 0.5, y: 0.5, w: 6, h: 4 })
+	const barZip = await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer)
+	const slideXml = await readPart(barZip, 'ppt/slides/slide1.xml')
+
+	assert.doesNotMatch(slideXml, /mc:AlternateContent/, 'an ECMA-376 chart needs no compatibility wrapper')
+	assert.match(slideXml, /<a:graphicData uri="http:\/\/schemas\.openxmlformats\.org\/drawingml\/2006\/chart">/, 'classic chart graphicData uri changed')
+	const chartParts = Object.keys(barZip.files).filter(name => /^ppt\/charts\/chart\d+\.xml$/.test(name))
+	assert.equal(chartParts.length, 1, 'classic chart part missing')
+	assert.equal(Object.keys(barZip.files).filter(name => /chartEx/.test(name)).length, 0, 'no chartex part may appear without a chartex chart')
+	assert.doesNotMatch(await readPart(barZip, '[Content_Types].xml'), /ms-office\.chartex/, 'no chartex content type may be declared without a chartex chart')
+	assert.equal(Object.keys(barZip.files).filter(name => /\/(colors|style)\d+\.xml$/.test(name)).length, 0, 'default classic charts must not write style or colors parts')
+})
+
+test('contract: chartex data that PowerPoint would reject is normalized, not emitted', async () => {
+	const warnings: string[] = []
+	const origWarn = console.warn
+	let ragged = ''
+	let multi = ''
+	let extra = ''
+	let noLabels = ''
+	try {
+		console.warn = (msg: string) => warnings.push(String(msg))
+		ragged = await chartExXml('waterfall', [{ name: 'Cash', labels: ['a', 'b', 'c', 'd'], values: [10, null, 30] }])
+		multi = await chartExXml('treemap', [{ name: 'R', labels: [['Gear', 'Berg', 'Motr'], ['Mech', '', '']], values: [1, 2, 3] }])
+		extra = await chartExXml('waterfall', [{ name: 'A', labels: ['a', 'b'], values: [1, 2] }, { name: 'B', labels: ['a', 'b'], values: [3, 4] }])
+		noLabels = await chartExXml('histogram', [{ name: 'Ages', values: [1, 2, 3] }])
+	} finally {
+		console.warn = origWarn
+	}
+
+	assert.doesNotMatch(ragged, />null<|>undefined</, 'a missing point must be blank, not the string "null"')
+	assert.match(ragged, /<cx:pt idx="1"><\/cx:pt>/, 'a missing point must still hold its index')
+	assert.match(ragged, /<cx:f>Sheet1!\$B\$2:\$B\$4<\/cx:f><cx:lvl ptCount="3"/, 'the value range must be as long as its ptCount')
+	assert.match(ragged, /<cx:f>Sheet1!\$A\$2:\$A\$5<\/cx:f><cx:lvl ptCount="4"/, 'the category range must be as long as its ptCount')
+
+	assert.match(multi, /<cx:f>Sheet1!\$A\$2:\$A\$4<\/cx:f><cx:lvl ptCount="3"><cx:pt idx="0">Gear/, 'the leaf label level must address column A')
+	assert.match(multi, /type="size"><cx:f>Sheet1!\$B\$2:\$B\$4</, 'values must stay in column B after flattening')
+	assert.doesNotMatch(multi, /Mech/, 'the extra label level must be dropped, not emitted')
+
+	assert.equal((extra.match(/<cx:series /g) ?? []).length, 1, 'a waterfall plots one series')
+	assert.match(noLabels, /<cx:numDim type="val"><cx:f>Sheet1!\$B\$2:\$B\$4</, 'a label-less histogram must still address its values')
+
+	assert.equal(warnings.length, 2, `expected one warning per normalization, got: ${warnings.join(' | ')}`)
+
+	const box = await chartExXml('boxWhisker', [{ name: 'A', labels: ['a', 'b'], values: [1, 2] }, { name: 'B', labels: ['a', 'b'], values: [3, 4] }])
+	assert.equal((box.match(/<cx:series /g) ?? []).length, 2, 'box & whisker plots one series per distribution')
+})
+
+test('contract: chartex options use the cx vocabulary, not the ECMA-376 one', async () => {
+	assert.match(
+		await chartExXml('treemap', [{ name: 'R', labels: ['a'], values: [1] }], { showLegend: true, legendPos: 'tr' }),
+		/<cx:legend pos="r" align="min" overlay="0"\/>/,
+		'top-right must become a top-aligned right legend'
+	)
+
+	const warnings: string[] = []
+	const origWarn = console.warn
+	let honoured = ''
+	let rejected = ''
+	try {
+		console.warn = (msg: string) => warnings.push(String(msg))
+		honoured = await chartExXml('waterfall', [{ name: 'C', labels: ['a', 'b'], values: [1, 2] }], { showValue: true, dataLabelPosition: 'ctr' })
+		rejected = await chartExXml('waterfall', [{ name: 'C', labels: ['a', 'b'], values: [1, 2] }], { showValue: true, dataLabelPosition: 'bestFit' })
+	} finally {
+		console.warn = origWarn
+	}
+
+	assert.match(honoured, /<cx:dataLabels pos="ctr">/, 'a valid chartex label position must survive')
+	assert.equal(warnings.length, 1, `only the unsupported position may warn, got: ${warnings.join(' | ')}`)
+	assert.match(rejected, /<cx:dataLabels pos="outEnd">/, 'an unsupported position falls back to the layout default')
+
+	const coloured = await chartExXml('funnel', [{ name: 'P', labels: ['a', 'b'], values: [5, 3], color: 'FF0000' }], { chartColors: ['00FF00'] })
+	assert.match(coloured, /<cx:spPr><a:solidFill><a:srgbClr val="FF0000"\/><\/a:solidFill><\/cx:spPr>/, 'an explicit series colour must be emitted')
+	assert.doesNotMatch(coloured, /00FF00/, 'chartColors does not apply to a chartex layout')
+})
+
+test('contract: the chartex fallback shape mirrors the chart frame it replaces', async () => {
+	const { zip } = await buildChartEx('waterfall', WATERFALL_DATA, { objectName: 'WF', title: 'Quarterly cash', showTitle: true })
+	const slideXml = await readPart(zip, 'ppt/slides/slide1.xml')
+	const fallback = slideXml.slice(slideXml.indexOf('<mc:Fallback>'), slideXml.indexOf('</mc:Fallback>'))
+
+	assert.match(fallback, /name="WF"/, 'the fallback must carry the chart name')
+	assert.doesNotMatch(fallback, /title="Quarterly cash"/, 'the chart title must not leak into the alt-text title')
+	assert.match(fallback, /<a:spLocks noTextEdit="1"\/>/, 'the fallback must never be text-editable')
+})

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -3507,3 +3507,60 @@ test('OMML: malformed omml option throws instead of writing a corrupt package', 
 	const xml = await readPart(await writeZip(pptx3), 'ppt/slides/slide1.xml')
 	assert.ok(xml.includes('a&lt;b&amp;c'), 'valid OMML was rejected or mangled')
 })
+
+test('#157: chart style and color parts are opt-in for classic charts', async () => {
+	const data = [{ name: 'S1', labels: ['a', 'b'], values: [1, 2] }]
+	const def = new pptxgen()
+	def.addSlide().addChart('bar', data, { x: 1, y: 1, w: 6, h: 4 })
+	const defZip = await writeZip(def)
+	assert.ok(!Object.keys(defZip.files).some(name => /\/(colors|style)\d+\.xml$/.test(name)), 'default classic charts must not write style or colors parts')
+	assert.ok(!(await readPart(defZip, '[Content_Types].xml')).includes('chartstyle'), 'default classic charts must not declare a chart style content type')
+
+	const pptx = new pptxgen()
+	pptx.addSlide().addChart('bar', data, { x: 1, y: 1, w: 6, h: 4, chartStyle: 201 })
+	pptx.addSlide().addChart('pie', data, { x: 1, y: 1, w: 6, h: 4, chartStyle: 251, chartColorStyle: { method: 'withinLinear', id: 13, colors: ['accent3', 'FF0000'] } })
+
+	const zip = await writeZip(pptx)
+	const chartParts = Object.keys(zip.files).filter(name => /^ppt\/charts\/(chart|colors|style)\d+\.xml$/.test(name)).sort()
+	const chartNums = chartParts.filter(name => /\/chart\d+\.xml$/.test(name)).map(name => /(\d+)\.xml$/.exec(name)?.[1] ?? '')
+	assert.equal(chartNums.length, 2, `expected two charts, got ${chartNums.join(',')}`)
+	for (const num of chartNums) {
+		assert.ok(chartParts.includes(`ppt/charts/colors${num}.xml`), `missing colors${num}.xml`)
+		assert.ok(chartParts.includes(`ppt/charts/style${num}.xml`), `missing style${num}.xml`)
+	}
+
+	const rels = await readPart(zip, `ppt/charts/_rels/chart${chartNums[0]}.xml.rels`)
+	assert.ok(rels.includes(`<Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2011/relationships/chartColorStyle" Target="colors${chartNums[0]}.xml"/>`), `colour-style relationship wrong: ${rels}`)
+	assert.ok(rels.includes(`<Relationship Id="rId3" Type="http://schemas.microsoft.com/office/2011/relationships/chartStyle" Target="style${chartNums[0]}.xml"/>`), `style relationship wrong: ${rels}`)
+	assert.ok(rels.includes('rId1'), 'the embedded workbook relationship was displaced')
+
+	const contentTypes = await readPart(zip, '[Content_Types].xml')
+	for (const num of chartNums) {
+		assert.ok(contentTypes.includes(`<Override PartName="/ppt/charts/colors${num}.xml" ContentType="application/vnd.ms-office.chartcolorstyle+xml"/>`), `colors${num}.xml content type missing`)
+		assert.ok(contentTypes.includes(`<Override PartName="/ppt/charts/style${num}.xml" ContentType="application/vnd.ms-office.chartstyle+xml"/>`), `style${num}.xml content type missing`)
+	}
+
+	const colors = await readPart(zip, `ppt/charts/colors${chartNums[0]}.xml`)
+	assert.ok(colors.includes('xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle"'), 'the cs namespace is wrong')
+	assert.ok(colors.includes('meth="cycle" id="10">'), `default colour style wrong: ${colors.slice(0, 300)}`)
+	assert.ok(colors.includes('<a:schemeClr val="accent1"/><a:schemeClr val="accent2"/>'), 'the default palette is not the theme accents')
+	assert.equal((colors.match(/<cs:variation/g) ?? []).length, 9, 'expected nine luminance variations')
+
+	const style = await readPart(zip, `ppt/charts/style${chartNums[0]}.xml`)
+	assert.ok(style.includes('<cs:chartStyle ') && style.includes(' id="201">'), `default style id wrong: ${style.slice(0, 260)}`)
+	assert.ok(style.includes('<cs:axisTitle>') && style.includes('<cs:dataPoint>') && style.includes('<cs:plotArea'), 'the style definitions are incomplete')
+
+	const colors2 = await readPart(zip, `ppt/charts/colors${chartNums[1]}.xml`)
+	assert.ok(colors2.includes('meth="withinLinear" id="13">'), `colour style override ignored: ${colors2.slice(0, 260)}`)
+	assert.ok(colors2.includes('<a:schemeClr val="accent3"/><a:srgbClr val="FF0000"/>'), 'a custom palette was ignored')
+	assert.ok((await readPart(zip, `ppt/charts/style${chartNums[1]}.xml`)).includes(' id="251">'), 'the style id override was ignored')
+
+	const chartXml = await readPart(zip, `ppt/charts/chart${chartNums[0]}.xml`)
+	assert.ok(!chartXml.includes('chartStyle') && !chartXml.includes('colorStyle'), 'chartN.xml should not reference the style parts')
+
+	const bare = new pptxgen()
+	bare.addSlide().addText('hi', { x: 1, y: 1 })
+	const bareZip = await writeZip(bare)
+	assert.ok(!Object.keys(bareZip.files).some(name => /colors\d+\.xml|style\d+\.xml/.test(name)), 'a chartless deck gained chart style parts')
+	assert.ok(!(await readPart(bareZip, '[Content_Types].xml')).includes('chartstyle'), 'a chartless deck gained a chart style content type')
+})


### PR DESCRIPTION
## Summary
- Port PowerPoint 2016+ ChartEx layouts (`boxWhisker`, `funnel`, `histogram`, `sunburst`, `treemap`, `waterfall`) as native `cx:chart` parts with Microsoft content/relationship types and an `mc:AlternateContent` fallback.
- Add opt-in `chartStyle` / `chartColorStyle` sidecars (`cs:chartStyle`, `cs:colorStyle`). Default classic `c:chart` packages stay unchanged; ChartEx always writes the style/colors parts PowerPoint requires.
- Semantic package-contract tests for rels, content types, `cx:chart` vs `c:chart`, and style parts. The std stacked-bar `waterfall()` helper is unchanged.

## Test plan
- [x] `bun test test/contracts.test.ts test/issues.test.ts`
- [x] `bun run typecheck`
- [x] `bun run test:std` (stacked-bar waterfall helper still emits `c:barChart`)
- [ ] Open a ChartEx deck in PowerPoint 2016+ and confirm the six layouts render
- [ ] Confirm a default bar chart still has no `styleN.xml` / `colorsN.xml`

Made with [Cursor](https://cursor.com)