### PR TITLE
feat: port Neoma table cell completeness, custom table styles, and media sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Table cells emit DrawingML `a:lnTlToBr` / `a:lnBlToTr` (`borderDiagonalDown` / `borderDiagonalUp`), `a:cell3D` (bevel, material, light rig), and `a:tcPr` `horzOverflow` / `anchorCtr`
+- `pptx.tableStyles` writes custom `a:tblStyle` definitions into `ppt/tableStyles.xml`; `tableStyleId` still accepts built-in PowerPoint GUIDs
+- `addMedia` sources: linked audio/video (`link` without `data`/`path`), `type: 'audioCd'`, `type: 'wav'` (`a:wavAudioFile`), plus `contentType`, `isPhoto`, and `userDrawn`
 - Text `vertOverflow` / `horzOverflow` emit ECMA-376 `a:bodyPr` overflow attrs so overflowing runs can clip instead of spilling out of the shape
 - Package-contract tests for opt-in `addFont` (Font parts, `application/x-fontdata`, Presentation font rels); default export embeds nothing
 - `pptx.slideShow` emits a spec-valid `p:showPr` with the required present/browse/kiosk choice, plus loop/narration/animation/timing flags

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/pptxgenjs-jsx": {
       "name": "pptxgenjs-plus-jsx",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "dependencies": {
         "pptxgenjs-plus": "file:../..",
       },
@@ -35,14 +35,14 @@
     },
     "packages/pptxgenjs-std": {
       "name": "pptxgenjs-plus-std",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "devDependencies": {
         "@types/node": "^26.2.0",
         "pptxgenjs-plus": "file:../..",
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "pptxgenjs-plus": "4.1.19",
+        "pptxgenjs-plus": "4.1.20",
       },
     },
   },

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1084,7 +1084,29 @@ export interface ThemeProps {
 }
 
 // image / media ==================================================================================
-export type MediaType = 'audio' | 'online' | 'video'
+export type MediaType = 'audio' | 'online' | 'video' | 'audioCd' | 'wav'
+
+/**
+ * A point on an audio CD (`a:st`/`a:end`, ECMA-376 Part 1 §20.1.3.4 CT_AudioCDTime)
+ */
+export interface AudioCdTimeProps {
+	/** CD track number (0-255) - required by the schema */
+	track: number
+	/**
+	 * Offset into the track, in seconds
+	 * @default 0
+	 */
+	time?: number
+}
+
+/**
+ * CD audio source (`a:audioCd`, ECMA-376 Part 1 §20.1.3.3 CT_AudioCD)
+ * - references the listener's CD drive, so it embeds nothing and needs no relationship
+ */
+export interface AudioCdProps {
+	start: AudioCdTimeProps
+	end: AudioCdTimeProps
+}
 
 export interface ImageProps extends PositionProps, DataOrPathProps, ObjectNameProps, AppearOnClickProps, NvPrExtensionProps {
 	/**
@@ -1320,6 +1342,26 @@ export interface MediaProps extends PositionProps, DataOrPathProps, ObjectNamePr
 	 * @default false
 	 */
 	mute?: boolean
+	/**
+	 * MIME type of the referenced media (`a:audioFile@contentType`, `a:videoFile@contentType`)
+	 * @example 'video/mp4'
+	 */
+	contentType?: string
+	/**
+	 * CD audio track range - required when `type` is `audioCd`
+	 * @example { start: { track: 1 }, end: { track: 1, time: 30 } }
+	 */
+	audioCd?: AudioCdProps
+	/**
+	 * Mark the media frame as a photo (`p:nvPr@isPhoto`)
+	 * @default false
+	 */
+	isPhoto?: boolean
+	/**
+	 * Mark the media frame as author-placed rather than layout furniture (`p:nvPr@userDrawn`)
+	 * @default false
+	 */
+	userDrawn?: boolean
 }
 
 // groups =========================================================================================
@@ -1582,6 +1624,55 @@ export interface TableToSlidesProps extends TableProps {
 	 */
 	newSlideStartY?: number
 }
+/**
+ * 3-D bevel applied to a table cell (`a:bevel`, ECMA-376 Part 1 §20.1.5.3 CT_Bevel)
+ */
+export interface CellBevelProps {
+	/**
+	 * Bevel shape
+	 * @default circle
+	 */
+	preset?: 'relaxedInset' | 'circle' | 'slope' | 'cross' | 'angle' | 'softRound' | 'convex' | 'coolSlant' | 'divot' | 'riblet' | 'hardEdge' | 'artDeco'
+	/**
+	 * Bevel width (inches)
+	 * @default 0.083
+	 */
+	width?: number
+	/**
+	 * Bevel height (inches)
+	 * @default 0.083
+	 */
+	height?: number
+}
+
+/**
+ * Light rig for a 3-D table cell (`a:lightRig`, ECMA-376 Part 1 §20.1.5.5 CT_LightRig)
+ * - both properties are required by the schema, so a partial value is not emitted
+ */
+export interface CellLightRigProps {
+	rig: 'legacyFlat1' | 'legacyFlat2' | 'legacyFlat3' | 'legacyFlat4' | 'legacyNormal1' | 'legacyNormal2' | 'legacyNormal3' | 'legacyNormal4' | 'legacyHarsh1' | 'legacyHarsh2' | 'legacyHarsh3' | 'legacyHarsh4' | 'threePt' | 'balanced' | 'soft' | 'harsh' | 'flood' | 'contrasting' | 'morning' | 'sunrise' | 'sunset' | 'chilly' | 'freezing' | 'flat' | 'twoPt' | 'glow' | 'brightRoom'
+	dir: 'tl' | 't' | 'tr' | 'l' | 'r' | 'bl' | 'b' | 'br'
+}
+
+/**
+ * 3-D properties of a table cell (`a:cell3D`, ECMA-376 Part 1 §21.1.3.1 CT_Cell3D)
+ */
+export interface Cell3DProps {
+	/**
+	 * Cell bevel
+	 * - `a:bevel` is required by the schema, so an `a:bevel` with schema defaults is written
+	 *   whenever `cell3D` is set
+	 */
+	bevel?: CellBevelProps
+	/**
+	 * Surface material
+	 * @default plastic
+	 */
+	material?: 'legacyMatte' | 'legacyPlastic' | 'legacyMetal' | 'legacyWireframe' | 'matte' | 'plastic' | 'metal' | 'warmMatte' | 'translucentPowder' | 'powder' | 'dkEdge' | 'softEdge' | 'clear' | 'flat' | 'softmetal'
+	/** Light rig - dropped unless both `rig` and `dir` are set */
+	lightRig?: CellLightRigProps
+}
+
 export interface TableCellProps extends TextBaseProps {
 	/**
 	 * Auto-paging character weight
@@ -1602,13 +1693,38 @@ export interface TableCellProps extends TextBaseProps {
 	 */
 	autoPageLineWeight?: number
 	/**
+	 * Whether text is centered both horizontally and vertically in the cell
+	 * @default false
+	 */
+	anchorCtr?: boolean
+	/**
 	 * Cell border
 	 */
 	border?: BorderProps | [BorderProps, BorderProps, BorderProps, BorderProps]
 	/**
+	 * Diagonal border running bottom-left to top-right (`a:lnBlToTr`)
+	 * - independent of `border`, which only covers the four edges
+	 */
+	borderDiagonalUp?: BorderProps
+	/**
+	 * Diagonal border running top-left to bottom-right (`a:lnTlToBr`)
+	 * - independent of `border`, which only covers the four edges
+	 */
+	borderDiagonalDown?: BorderProps
+	/**
+	 * 3-D bevel and lighting for the cell
+	 * @example { bevel: { preset: 'circle', width: 0.05, height: 0.05 }, material: 'metal' }
+	 */
+	cell3D?: Cell3DProps
+	/**
 	 * Cell colspan
 	 */
 	colspan?: number
+	/**
+	 * Whether text wider than the cell is clipped or allowed to overflow it
+	 * @default clip
+	 */
+	horzOverflow?: 'clip' | 'overflow'
 	/**
 	 * Fill color
 	 * @example { color:'FF0000' } // hex color (red)
@@ -1750,7 +1866,7 @@ export interface TableProps extends PositionProps, TextBaseProps, ObjectNameProp
 	 */
 	rtlMode?: boolean
 	/**
-	 * Table style id (GUID of a built-in PowerPoint table style)
+	 * Table style id (GUID of a built-in PowerPoint table style, or a custom style from `pptx.tableStyles`)
 	 * - required for `bandRow`/`firstRow`/etc. to have a visible effect
 	 * @example '{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}' // "Medium Style 2 - Accent 1"
 	 */
@@ -1772,6 +1888,72 @@ export interface TableProps extends PositionProps, TextBaseProps, ObjectNameProp
 	 */
 	newSlideStartY?: number
 }
+
+/**
+ * Borders of one part of a table style (`a:tcBdr`, ECMA-376 Part 1 §21.1.3.11)
+ */
+export interface TableStyleBorderProps {
+	left?: ShapeLineProps
+	right?: ShapeLineProps
+	top?: ShapeLineProps
+	bottom?: ShapeLineProps
+	/** horizontal borders between rows */
+	insideH?: ShapeLineProps
+	/** vertical borders between columns */
+	insideV?: ShapeLineProps
+}
+
+/**
+ * How one part of a table looks in a table style (`a:wholeTbl`, `a:band1H`, `a:firstRow`, ...)
+ * - `a:tcTxStyle` carries the text half, `a:tcStyle` the cell half
+ */
+export interface TableStylePartProps {
+	/** bold text - omitted leaves it to the theme */
+	bold?: boolean
+	/** italic text - omitted leaves it to the theme */
+	italic?: boolean
+	/** text colour */
+	color?: Color
+	/** cell fill */
+	fill?: ShapeFillProps
+	/** cell borders */
+	borders?: TableStyleBorderProps
+}
+
+/**
+ * A custom table style, written into `ppt/tableStyles.xml` (ECMA-376 Part 1 §14.2.9)
+ * - reference it from a table with `tableStyleId: '<the same id>'`
+ * - `id` and `name` are both required by the schema
+ */
+export interface TableStyleProps {
+	/** Style GUID, braced and upper-case, e.g. `{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}` */
+	id: string
+	/** Name shown in PowerPoint's table-style gallery */
+	name: string
+	/** applies to every cell */
+	wholeTable?: TableStylePartProps
+	/** first banded row */
+	band1H?: TableStylePartProps
+	/** second banded row */
+	band2H?: TableStylePartProps
+	/** first banded column */
+	band1V?: TableStylePartProps
+	/** second banded column */
+	band2V?: TableStylePartProps
+	firstRow?: TableStylePartProps
+	lastRow?: TableStylePartProps
+	firstCol?: TableStylePartProps
+	lastCol?: TableStylePartProps
+	/** top-left cell */
+	nwCell?: TableStylePartProps
+	/** top-right cell */
+	neCell?: TableStylePartProps
+	/** bottom-left cell */
+	swCell?: TableStylePartProps
+	/** bottom-right cell */
+	seCell?: TableStylePartProps
+}
+
 export interface TableCell {
 	/** @internal assigned by the table builder; consumers pass plain `{ text, options }` objects */
 	_type?: SLIDE_OBJECT_TYPES.tablecell
@@ -2660,6 +2842,12 @@ export interface ISlideRelMedia {
 	data?: string | ArrayBuffer
 	/** used to indicate that a media file has already been read/enocded (PERF) */
 	isDuplicate?: boolean
+	/**
+	 * Media referenced rather than embedded: the relationship is written `TargetMode="External"`
+	 * and no part is added to the package
+	 * @internal
+	 */
+	isLinked?: boolean
 	isSvgPng?: boolean
 	/** SVG path recolor (Martin-N) — applied when encoding SVG media */
 	fill?: ShapeFillProps
@@ -2684,6 +2872,12 @@ export interface ISlideObject {
 	media?: string
 	mtype?: MediaType
 	mediaRid?: number
+	/**
+	 * rId of the media frame's preview image - the media source kinds push different numbers of
+	 * relationships, so the cover cannot be derived from `mediaRid`
+	 * @internal
+	 */
+	_coverRid?: number
 	shape?: SHAPE_NAME
 	/** @internal group children (`p:grpSp`) */
 	_objects?: ISlideObject[]
@@ -2889,6 +3083,16 @@ export interface ObjectOptions extends ImageProps, PositionProps, ShapeProps, Ta
 	loop?: boolean
 	fullScreen?: boolean
 	mute?: boolean
+	/** MIME type of referenced media (`a:audioFile@contentType`) @internal */
+	contentType?: string
+	/** CD audio track range (`a:audioCd`) @internal */
+	audioCd?: AudioCdProps
+	/** media frame marked as a photo (`p:nvPr@isPhoto`) @internal */
+	isPhoto?: boolean
+	/** author-placed rather than layout furniture (`p:nvPr@userDrawn`) @internal */
+	userDrawn?: boolean
+	/** media referenced rather than embedded @internal */
+	isLinked?: boolean
 	// MS-PPTX §2.8 CT_ZoomObjectProperties (zoom objects only)
 	returnToParent?: boolean
 	showBg?: boolean
@@ -3287,6 +3491,11 @@ export interface PresentationProps {
 	 * @default false
 	 */
 	rtlMode: boolean
+	/**
+	 * Custom table style definitions written into `ppt/tableStyles.xml`
+	 * - reference one from a table with `tableStyleId`
+	 */
+	tableStyles?: TableStyleProps[]
 	/**
 	 * Starting slide number written to `ppt/presentation.xml` (`firstSlideNum`)
 	 * - PowerPoint: Design > Slide Size > Custom Slide Size > Number slides from

--- a/src/gen-media.ts
+++ b/src/gen-media.ts
@@ -122,7 +122,7 @@ export function applyNaturalImageSizes(layout: PresSlide | SlideLayout): void {
 /** Select relations that still need their local or remote media encoded. */
 function getMediaCandidates(layout: PresSlide | SlideLayout): ISlideRelMedia[] {
 	return layout._relsMedia.filter(
-		rel => rel.type !== 'online' && !rel.data && (!rel.path || (rel.path && !rel.path.includes('preencoded')))
+		rel => !rel.isLinked && rel.type !== 'online' && !rel.data && (!rel.path || (rel.path && !rel.path.includes('preencoded')))
 	)
 }
 

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -709,12 +709,25 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 	const objectName = opt.objectName ? encodeXmlEntities(opt.objectName) : `Media ${target._slideObjects.filter(obj => obj._type === SLIDE_OBJECT_TYPES.media).length}`
 	const slideData: ISlideObject = { _type: SLIDE_OBJECT_TYPES.media }
 
-	// STEP 1: REALITY-CHECK
-	if (!strPath && !strData && strType !== 'online') {
+	// `link` with no `path`/`data` used to throw, so treating it as "reference, do not embed" cannot
+	// change any deck that works today
+	const isLinked = !!strLink && !strPath && !strData && (strType === 'audio' || strType === 'video')
+	if (strLink && (strPath || strData) && strType !== 'online') {
+		console.warn('[pptxgenjs] addMedia: `link` is ignored when `path` or `data` is given - the media is embedded')
+	}
+
+	// STEP 1: REALITY-CHECK - what each media kind needs, rather than one chain of conditions
+	if (strType === 'audioCd') {
+		// `a:st`/`a:end` and their `@track` are all required by CT_AudioCD
+		if (typeof opt.audioCd?.start?.track !== 'number' || typeof opt.audioCd?.end?.track !== 'number') {
+			throw new Error('addMedia() error: `type:"audioCd"` requires `audioCd.start.track` and `audioCd.end.track`')
+		}
+	} else if (!strPath && !strData && strType !== 'online' && !isLinked) {
 		throw new Error('addMedia() error: either `data` or `path` are required!')
 	} else if (strData && !strData.toLowerCase().includes('base64,')) {
 		throw new Error('addMedia() error: `data` value lacks a base64 header! Ex: \'video/mpeg;base64,NMP[...]\')')
-	} else if (strCover && !strCover.toLowerCase().includes('base64,')) {
+	}
+	if (strCover && !strCover.toLowerCase().includes('base64,')) {
 		throw new Error('addMedia() error: `cover` value lacks a base64 header! Ex: \'data:image/png;base64,iV[...]\')')
 	}
 	// Online Video: requires `link`
@@ -723,7 +736,7 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 	}
 	// Timing-tree playback (ECMA-376 §19.5 CT_TLMediaNode): no silent fallbacks.
 	// `fullScrn` exists only on CT_TLMediaNodeVideo; linked `online` media has no embedded media node.
-	if (strType === 'audio' && opt.fullScreen) {
+	if (opt.fullScreen && strType !== 'video') {
 		throw new Error('addMedia() error: `fullScreen` is only valid on type "video"')
 	}
 	if (strType === 'online' && (opt.autoplay || opt.loop || opt.fullScreen || opt.mute)) {
@@ -732,7 +745,7 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 
 	// FIXME: 20190707
 	// strType = strData ? strData.split(';')[0].split('/')[0] : strType
-	strExtn = opt.extn || (strData ? strData.split(';')[0].split('/')[1] : strPath.split('.').pop()) || 'mp3'
+	strExtn = opt.extn || (strType === 'wav' ? 'wav' : strData ? strData.split(';')[0].split('/')[1] : (strPath || strLink).split('.').pop()) || 'mp3'
 
 	// STEP 2: Set type, media
 	slideData.mtype = strType
@@ -761,6 +774,11 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 	slideData.options.loop = opt.loop
 	slideData.options.fullScreen = opt.fullScreen
 	slideData.options.mute = opt.mute
+	slideData.options.contentType = opt.contentType
+	slideData.options.audioCd = opt.audioCd
+	slideData.options.isPhoto = opt.isPhoto
+	slideData.options.userDrawn = opt.userDrawn
+	slideData.options.isLinked = isLinked
 
 	// STEP 4: Add this media to this Slide Rels (rId/rels count spans all slides! Count all media to get next rId)
 	/**
@@ -772,7 +790,41 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 	 * <Relationship Id="rId2" Target="../media/media1.mov" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video"/>
 	 * <Relationship Id="rId3" Target="../media/media1.mov" Type="http://schemas.microsoft.com/office/2007/relationships/media"/>
 	 */
-	if (strType === 'online') {
+	if (strType === 'audioCd') {
+		// CD audio references the listener's drive: no media part, no media relationship, cover only
+		const coverRid = getNewRelId(target)
+		target._relsMedia.push({
+			path: 'preencoded.png',
+			type: 'image/png',
+			extn: 'png',
+			data: strCover,
+			rId: coverRid,
+			Target: `../media/${imageTargetStem(target)}.png`,
+		})
+		slideData._coverRid = coverRid
+	} else if (strType === 'wav') {
+		// `a:wavAudioFile` is the legacy embedded-WAV element: one audio relationship, no `p14:media`
+		const relId1 = getNewRelId(target)
+		target._relsMedia.push({
+			path: strPath || 'preencoded.wav',
+			type: 'audio/wav',
+			extn: 'wav',
+			data: strData || '',
+			rId: relId1,
+			Target: `../media/media-${target._slideNum}-${target._relsMedia.length + 1}.wav`,
+		})
+		slideData.mediaRid = relId1
+		const coverRid = getNewRelId(target)
+		target._relsMedia.push({
+			path: 'preencoded.png',
+			type: 'image/png',
+			extn: 'png',
+			data: strCover,
+			rId: coverRid,
+			Target: `../media/${imageTargetStem(target)}.png`,
+		})
+		slideData._coverRid = coverRid
+	} else if (strType === 'online') {
 		const relId1 = getNewRelId(target)
 		// A: Add video
 		target._relsMedia.push({
@@ -799,6 +851,8 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 		const dupeItem = target._relsMedia.filter(item => item.path && item.path === strPath && item.type === strType + '/' + strExtn && !item.isDuplicate)[0]
 
 		// A: "relationships/video"
+		// Linked media keeps this exact three-relationship shape - the rIds the emitter derives from
+		// `mediaRid` stay valid - and only points the targets outside the package
 		const relId1 = getNewRelId(target)
 		target._relsMedia.push({
 			path: strPath || 'preencoded' + strExtn,
@@ -807,7 +861,8 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 			data: strData || '',
 			rId: relId1,
 			isDuplicate: !!(dupeItem?.Target),
-			Target: dupeItem?.Target ? dupeItem.Target : `../media/media-${target._slideNum}-${target._relsMedia.length + 1}.${strExtn}`,
+			isLinked,
+			Target: isLinked ? strLink : (dupeItem?.Target ? dupeItem.Target : `../media/media-${target._slideNum}-${target._relsMedia.length + 1}.${strExtn}`),
 		})
 		slideData.mediaRid = relId1
 
@@ -819,7 +874,8 @@ export function addMediaDefinition(target: PresSlide, opt: MediaProps): void {
 			data: strData || '',
 			rId: getNewRelId(target),
 			isDuplicate: !!(dupeItem?.Target),
-			Target: dupeItem?.Target ? dupeItem.Target : `../media/media-${target._slideNum}-${target._relsMedia.length + 0}.${strExtn}`,
+			isLinked,
+			Target: isLinked ? strLink : (dupeItem?.Target ? dupeItem.Target : `../media/media-${target._slideNum}-${target._relsMedia.length + 0}.${strExtn}`),
 		})
 
 		// C: Add cover (preview/overlay) image

--- a/src/pptxgen.ts
+++ b/src/pptxgen.ts
@@ -100,6 +100,7 @@ import {
 	SlideMasterProps,
 	SlideShowProps,
 	SlideNumberProps,
+	TableStyleProps,
 	TableToSlidesProps,
 	ThemeProps,
 	WriteBaseProps,
@@ -276,6 +277,16 @@ export default class PptxGenJS implements IPresentationProps {
 
 	public get rtlMode(): boolean {
 		return this._rtlMode
+	}
+
+	/** tableStyles - custom table style definitions written into `ppt/tableStyles.xml` */
+	private _tableStyles?: TableStyleProps[]
+	public set tableStyles(value: TableStyleProps[] | undefined) {
+		this._tableStyles = value
+	}
+
+	public get tableStyles(): TableStyleProps[] | undefined {
+		return this._tableStyles
 	}
 
 	/**
@@ -618,7 +629,7 @@ export default class PptxGenJS implements IPresentationProps {
 	private readonly createChartMediaRels = (slide: PresSlide | SlideLayout, zip: JSZip, chartPromises: Promise<string>[], mediaPaths: Set<string>): void => {
 		slide._relsChart.forEach(rel => chartPromises.push(genCharts.createExcelWorksheet(rel, zip)))
 		slide._relsMedia.forEach(rel => {
-			if (rel.type !== 'online' && rel.type !== 'hyperlink') {
+			if (!rel.isLinked && rel.type !== 'online' && rel.type !== 'hyperlink') {
 				// A: Loop vars
 				let data: string = rel.data && typeof rel.data === 'string' ? rel.data : ''
 
@@ -728,7 +739,7 @@ export default class PptxGenJS implements IPresentationProps {
 			zip.file('ppt/theme/theme2.xml', genXml.makeXmlTheme(this, 'notes'))
 			zip.file('ppt/presentation.xml', genXml.makeXmlPresentation(this))
 			zip.file('ppt/presProps.xml', genXml.makeXmlPresProps(this))
-			zip.file('ppt/tableStyles.xml', genXml.makeXmlTableStyles())
+			zip.file('ppt/tableStyles.xml', genXml.makeXmlTableStyles(this._tableStyles))
 			zip.file('ppt/viewProps.xml', genXml.makeXmlViewProps())
 
 			// C: Create a Layout/Master/Rel/Slide file for each SlideLayout and Slide

--- a/src/xml/package.ts
+++ b/src/xml/package.ts
@@ -14,15 +14,18 @@ import {
 	SlideObjectAnimation,
 	SlideShowEvent,
 	SlideShowProps,
+	TableStyleBorderProps,
+	TableStylePartProps,
+	TableStyleProps,
 	TextProps,
 } from '../core-interfaces'
 import { createTimingXml, MediaPlaybackEntry } from '../gen-animations'
 import { genXmlTransition } from '../gen-transition'
 import { AUTHOR_PART_CONTENT_TYPE, AUTHOR_REL_TYPE, COMMENT_PART_CONTENT_TYPE, COMMENT_REL_URI, P188_NS } from '../gen-comments'
-import { createColorElement, encodeXmlEntities, getUuid, resolveThemeColors } from '../gen-utils'
+import { createColorElement, encodeXmlEntities, genXmlColorSelection, getUuid, resolveThemeColors } from '../gen-utils'
 import { extPartPackagePath } from './content-parts'
 import { slideCommentsRelId } from './relationships'
-import { resolveZoomSections, slideObjectToXml } from './slide'
+import { genXmlLine, resolveZoomSections, slideObjectToXml } from './slide'
 import { A14_NS, genXmlDesignTagLst, MATH_NS, MC_NS, P14_NS, P1710_NS, URI_DESIGN_TAG_LST } from './text'
 import {
 	CHANGES_INFO_CONTENT_TYPE,
@@ -114,7 +117,7 @@ export function makeXmlContTypes (slides: PresSlide[], slideLayouts: SlideLayout
 	strXml += '<Default Extension="mp4" ContentType="video/mp4"/>' // NOTE: Hard-Code this extension as it wont be created in loop below (as extn !== type)
 	slides.forEach(slide => {
 		(slide._relsMedia || []).forEach(rel => {
-			if (rel.type !== 'image' && rel.type !== 'online' && rel.type !== 'chart' && rel.extn !== 'm4v' && !strXml.includes(rel.type)) {
+			if (!rel.isLinked && rel.type !== 'image' && rel.type !== 'online' && rel.type !== 'chart' && rel.extn !== 'm4v' && !strXml.includes(rel.type)) {
 				strXml += '<Default Extension="' + rel.extn + '" ContentType="' + rel.type + '"/>'
 			}
 		})
@@ -190,7 +193,7 @@ export function makeXmlContTypes (slides: PresSlide[], slideLayouts: SlideLayout
 		strXml += ' <Override PartName="' + rel.Target + '" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>'
 	})
 	; (masterSlide?._relsMedia ?? []).forEach(rel => {
-		if (rel.type !== 'image' && rel.type !== 'online' && rel.type !== 'chart' && rel.extn !== 'm4v' && !strXml.includes(rel.type)) { strXml += ' <Default Extension="' + rel.extn + '" ContentType="' + rel.type + '"/>' }
+		if (!rel.isLinked && rel.type !== 'image' && rel.type !== 'online' && rel.type !== 'chart' && rel.extn !== 'm4v' && !strXml.includes(rel.type)) { strXml += ' <Default Extension="' + rel.extn + '" ContentType="' + rel.type + '"/>' }
 	})
 
 	// LAST: Finish XML (Resume core)
@@ -332,7 +335,7 @@ export function makeXmlPresentationRels (slides: PresSlide[], tracking?: Present
 function collectMediaPlayback (slide: PresSlide): MediaPlaybackEntry[] {
 	const entries: MediaPlaybackEntry[] = []
 	;(slide._slideObjects ?? []).forEach(obj => {
-		if (obj._type !== SLIDE_OBJECT_TYPES.media || obj.mtype === 'online') return
+		if (obj._type !== SLIDE_OBJECT_TYPES.media || (obj.mtype !== 'audio' && obj.mtype !== 'video')) return
 		const o = obj.options
 		// Defaults are all false: no timing node unless at least one playback flag is set.
 		if (!o || !(o.autoplay || o.loop || o.fullScreen || o.mute)) return
@@ -760,8 +763,93 @@ function makeXmlPresPropsExtLst (pres?: IPresentationProps): string {
  * @see: http://openxmldeveloper.org/discussions/formats/f/13/p/2398/8107.aspx
  * @return {string} XML
  */
-export function makeXmlTableStyles (): string {
-	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}<a:tblStyleLst xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" def="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"/>`
+/**
+ * The GUID `a:tblStyleLst@def` has always carried - PowerPoint's "Medium Style 2 - Accent 1"
+ */
+const DEF_TABLE_STYLE_ID = '{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}'
+
+/**
+ * CT_TableStyle fixes this child order, and it is neither alphabetical nor the intuitive one:
+ * `lastCol` precedes `firstCol`, and `firstRow` sits between `swCell` and `neCell`.
+ */
+const TABLE_STYLE_PARTS: Array<[keyof TableStyleProps, string]> = [
+	['wholeTable', 'wholeTbl'],
+	['band1H', 'band1H'],
+	['band2H', 'band2H'],
+	['band1V', 'band1V'],
+	['band2V', 'band2V'],
+	['lastCol', 'lastCol'],
+	['firstCol', 'firstCol'],
+	['lastRow', 'lastRow'],
+	['seCell', 'seCell'],
+	['swCell', 'swCell'],
+	['firstRow', 'firstRow'],
+	['neCell', 'neCell'],
+	['nwCell', 'nwCell'],
+]
+
+/** CT_TableCellBorderStyle child order */
+const TABLE_STYLE_BORDERS: Array<keyof TableStyleBorderProps> = ['left', 'right', 'top', 'bottom', 'insideH', 'insideV']
+
+/**
+ * One part of a table style (`a:wholeTbl`, `a:band1H`, ...).
+ * - `a:tcTxStyle` precedes `a:tcStyle`; inside the cell style, `a:tcBdr` precedes the fill
+ */
+function genXmlTableStylePart (tag: string, part: TableStylePartProps): string {
+	// `b`/`i` are ST_OnOffStyleType: an unset property means "def", i.e. leave it to the theme
+	const bold = typeof part.bold === 'boolean' ? ` b="${part.bold ? 'on' : 'off'}"` : ''
+	const italic = typeof part.italic === 'boolean' ? ` i="${part.italic ? 'on' : 'off'}"` : ''
+	const txStyle = bold || italic || part.color
+		? `<a:tcTxStyle${bold}${italic}>${part.color ? createColorElement(part.color) : ''}</a:tcTxStyle>`
+		: ''
+
+	const borders = TABLE_STYLE_BORDERS
+		.filter(edge => part.borders?.[edge])
+		.map(edge => {
+			const line = part.borders?.[edge]
+			return line ? `<a:${edge}>${genXmlLine(line)}</a:${edge}>` : ''
+		})
+		.join('')
+	const fill = part.fill ? `<a:fill>${genXmlColorSelection(part.fill)}</a:fill>` : ''
+	const cellStyle = borders || fill ? `<a:tcStyle>${borders ? `<a:tcBdr>${borders}</a:tcBdr>` : ''}${fill}</a:tcStyle>` : ''
+
+	return txStyle || cellStyle ? `<a:${tag}>${txStyle}${cellStyle}</a:${tag}>` : ''
+}
+
+/**
+ * Creates `ppt/tableStyles.xml`
+ * - with no custom styles this is the same self-closing stub earlier versions wrote
+ * @param {TableStyleProps[]} [styles] - custom table style definitions
+ * @return {string} XML
+ */
+export function makeXmlTableStyles (styles?: TableStyleProps[]): string {
+	const valid = (styles ?? []).filter(style => {
+		// `@styleId` is an ST_Guid and `@styleName` is required; a malformed id would be rejected on open
+		if (!/^\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}$/.test(style?.id ?? '')) {
+			console.warn(`[pptxgenjs] table style \`id\` must be a braced GUID, e.g. '{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}' - "${String(style?.id)}" ignored`)
+			return false
+		}
+		if (!style.name) {
+			console.warn(`[pptxgenjs] table style ${style.id} has no \`name\` - ignored`)
+			return false
+		}
+		return true
+	})
+
+	const head = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}<a:tblStyleLst xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" def="${DEF_TABLE_STYLE_ID}"`
+	if (valid.length === 0) return `${head}/>`
+
+	const body = valid.map(style => {
+		const parts = TABLE_STYLE_PARTS
+			.map(([prop, tag]) => {
+				const part = style[prop]
+				return part && typeof part === 'object' ? genXmlTableStylePart(tag, part) : ''
+			})
+			.join('')
+		return `<a:tblStyle styleId="${style.id}" styleName="${encodeXmlEntities(style.name)}">${parts}</a:tblStyle>`
+	}).join('')
+
+	return `${head}>${body}</a:tblStyleLst>`
 }
 
 /**

--- a/src/xml/relationships.ts
+++ b/src/xml/relationships.ts
@@ -51,17 +51,19 @@ function slideObjectRelationsToXml (slide: PresSlide | SlideLayout, defaultRels:
 			strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="' + rel.Target + '"/>'
 		} else if (rel.type.toLowerCase().includes('audio')) {
 			// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
+			const externalAttr = rel.isLinked ? ' TargetMode="External"' : ''
 			if (strXml.includes(' Target="' + rel.Target + '"')) {
-				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"/>'
+				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"' + externalAttr + '/>'
 			} else {
-				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/audio" Target="' + rel.Target + '"/>'
+				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/audio" Target="' + rel.Target + '"' + externalAttr + '/>'
 			}
 		} else if (rel.type.toLowerCase().includes('video')) {
 			// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
+			const externalAttr = rel.isLinked ? ' TargetMode="External"' : ''
 			if (strXml.includes(' Target="' + rel.Target + '"')) {
-				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"/>'
+				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"' + externalAttr + '/>'
 			} else {
-				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video" Target="' + rel.Target + '"/>'
+				strXml += '<Relationship Id="rId' + relRid + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video" Target="' + rel.Target + '"' + externalAttr + '/>'
 			}
 		} else if (rel.type.toLowerCase().includes('online')) {
 			// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style

--- a/src/xml/slide.ts
+++ b/src/xml/slide.ts
@@ -4,6 +4,7 @@
 
 import {
 	ANCHOR,
+	DEF_CELL_BORDER,
 	DEF_CELL_MARGIN_IN,
 	DEF_PRES_LAYOUT_NAME,
 	DEF_TEXT_SHADOW,
@@ -13,7 +14,9 @@ import {
 	SLIDE_OBJECT_TYPES,
 } from '../core-enums'
 import {
+	AudioCdTimeProps,
 	BlurProps,
+	BorderProps,
 	Coord,
 	ISlideObject,
 	ObjectOptions,
@@ -52,7 +55,8 @@ function nvPrModIdExt (modId?: number): string {
 }
 
 function genXmlNvPr (options?: ObjectOptions, phXml = '', extraExts: string[] = []): string {
-	return `<p:nvPr>${phXml}${genXmlNvPrExtLst(options, extraExts)}</p:nvPr>`
+	const attrs = (options?.isPhoto === true ? ' isPhoto="1"' : '') + (options?.userDrawn === true ? ' userDrawn="1"' : '')
+	return `<p:nvPr${attrs}>${phXml}${genXmlNvPrExtLst(options, extraExts)}</p:nvPr>`
 }
 
 const ImageSizingXml = {
@@ -119,11 +123,6 @@ function genXmlTblPr (opts: TableProps): string {
 }
 
 /**
- * Create the `a:ln` outline block for a shape/image
- * @param {ShapeLineProps} line - line options
- * @return {string} XML
- */
-/**
  * Builds `<p14:trim>` / `<p14:fade>` / `<p14:bmkLst>` children of `<p14:media>` (MS-PPTX §2.3.3.14).
  * Times are ST_UniversalTimeOffset (ms).
  */
@@ -138,7 +137,46 @@ function genXmlMediaExtras (opts: ObjectOptions): string {
 	return xml
 }
 
-function genXmlLine (line: ShapeLineProps): string {
+/**
+ * One `a:tcPr` border line (`a:lnL`, `a:lnTlToBr`, ...)
+ * - the four edges and the two diagonals share CT_LineProperties, so they share this emitter
+ * @param {string} name - element name without the `a:` prefix
+ * @param {BorderProps} border - border definition
+ * @returns {string} XML
+ */
+function genXmlCellBorder (name: string, border: BorderProps): string {
+	if (border.type === 'none') return `<a:${name} w="0" cap="flat" cmpd="sng" algn="ctr"><a:noFill/></a:${name}>`
+
+	const width = border.width ?? border.pt ?? DEF_CELL_BORDER.pt
+	const borderTransparency = border.transparency
+	const borderAlpha = typeof borderTransparency === 'number'
+		? `<a:alpha val="${Math.round((100 - Math.min(100, Math.max(0, borderTransparency))) * 1000)}"/>`
+		: ''
+	return (
+		`<a:${name} w="${valToPts(width)}" cap="flat" cmpd="sng" algn="ctr">` +
+		`<a:solidFill>${createColorElement(border.color ?? DEF_CELL_BORDER.color, borderAlpha)}</a:solidFill>` +
+		`<a:prstDash val="${border.type === 'dash' ? 'sysDash' : 'solid'}"/><a:round/>` +
+		'<a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/>' +
+		`</a:${name}>`
+	)
+}
+
+/**
+ * One `a:audioCd` endpoint (`a:st` or `a:end`).
+ * - `@track` is required and is an `xsd:unsignedByte`, so it is clamped; `@time` defaults to 0
+ */
+function genXmlAudioCdTime (tag: string, point?: AudioCdTimeProps): string {
+	const track = Math.min(255, Math.max(0, Math.round(point?.track ?? 0)))
+	const time = typeof point?.time === 'number' && isFinite(point.time) && point.time > 0 ? ` time="${Math.round(point.time)}"` : ''
+	return `<${tag} track="${track}"${time}/>`
+}
+
+/**
+ * Create the `a:ln` outline block for a shape/image
+ * @param {ShapeLineProps} line - line options
+ * @return {string} XML
+ */
+export function genXmlLine (line: ShapeLineProps): string {
 	// ECMA-376 §5.1.2.1.34: `<a:ln>` carries `w` and `cap` attributes (cap = line ending style, issue #782)
 	const attrs = (line.width ? ` w="${valToPts(line.width)}"` : '') + (line.cap && ['flat', 'sq', 'rnd'].includes(line.cap) ? ` cap="${line.cap}"` : '')
 	let xml = `<a:ln${attrs}>`
@@ -761,10 +799,11 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 									cellMargin[2]
 								)}"`
 
-							// FUTURE: Cell NOWRAP property (textwrap: add to a:tcPr (horzOverflow="overflow" or whatever options exist)
+							const cellOverflow = cellOpts.horzOverflow === 'overflow' || cellOpts.horzOverflow === 'clip' ? ` horzOverflow="${cellOpts.horzOverflow}"` : ''
+							const cellAnchorCtr = cellOpts.anchorCtr === true ? ' anchorCtr="1"' : ''
 
 							// 4: Set CELL content and properties ==================================
-							strXml += `<a:tc${cellSpanAttrStr}>${genXmlTextBody(cell)}<a:tcPr${cellMarginXml}${cellValign}${cellTextDir}>`
+							strXml += `<a:tc${cellSpanAttrStr}>${genXmlTextBody(cell)}<a:tcPr${cellMarginXml}${cellValign}${cellTextDir}${cellAnchorCtr}${cellOverflow}>`
 							// strXml += `<a:tc${cellColspan}${cellRowspan}>${genXmlTextBody(cell)}<a:tcPr${cellMarginXml}${cellValign}${cellTextDir}>`
 							// FIXME: 20200525: ^^^
 							// <a:tcPr marL="38100" marR="38100" marT="38100" marB="38100" vert="vert270">
@@ -778,21 +817,27 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 									{ idx: 1, name: 'lnR' },
 									{ idx: 0, name: 'lnT' },
 									{ idx: 2, name: 'lnB' },
-								].forEach(obj => {
-									if (border[obj.idx].type !== 'none') {
-										const borderTransparency = border[obj.idx].transparency
-										const borderAlpha = typeof borderTransparency === 'number'
-											? `<a:alpha val="${Math.round((100 - Math.min(100, Math.max(0, borderTransparency))) * 1000)}"/>`
-											: ''
-										strXml += `<a:${obj.name} w="${valToPts(border[obj.idx].pt)}" cap="flat" cmpd="sng" algn="ctr">`
-										strXml += `<a:solidFill>${createColorElement(border[obj.idx].color, borderAlpha)}</a:solidFill>`
-										strXml += `<a:prstDash val="${border[obj.idx].type === 'dash' ? 'sysDash' : 'solid'
-										}"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/>`
-										strXml += `</a:${obj.name}>`
-									} else {
-										strXml += `<a:${obj.name} w="0" cap="flat" cmpd="sng" algn="ctr"><a:noFill/></a:${obj.name}>`
-									}
-								})
+								].forEach(obj => { strXml += genXmlCellBorder(obj.name, border[obj.idx]) })
+							}
+
+							// 5b: Diagonals follow the four edges in the CT_TableCellProperties sequence, and are
+							// written only when asked for - unlike the edges, which are always emitted as a set
+							if (cellOpts.borderDiagonalDown) strXml += genXmlCellBorder('lnTlToBr', cellOpts.borderDiagonalDown)
+							if (cellOpts.borderDiagonalUp) strXml += genXmlCellBorder('lnBlToTr', cellOpts.borderDiagonalUp)
+
+							// 5c: `a:cell3D` follows the diagonals and precedes the fill
+							if (cellOpts.cell3D) {
+								const cell3D = cellOpts.cell3D
+								const bevel = cell3D.bevel ?? {}
+								let bevelAttrs = ''
+								if (typeof bevel.width === 'number' && isFinite(bevel.width) && bevel.width >= 0) bevelAttrs += ` w="${inch2Emu(bevel.width)}"`
+								if (typeof bevel.height === 'number' && isFinite(bevel.height) && bevel.height >= 0) bevelAttrs += ` h="${inch2Emu(bevel.height)}"`
+								if (bevel.preset) bevelAttrs += ` prst="${bevel.preset}"`
+								// `rig` and `dir` are both required on CT_LightRig, so a partial rig is dropped rather
+								// than emitted as an element PowerPoint would refuse to open
+								const lightRig = cell3D.lightRig?.rig && cell3D.lightRig.dir ? `<a:lightRig rig="${cell3D.lightRig.rig}" dir="${cell3D.lightRig.dir}"/>` : ''
+								// `a:bevel` is required by the schema, so it is always written
+								strXml += `<a:cell3D${cell3D.material ? ` prstMaterial="${cell3D.material}"` : ''}><a:bevel${bevelAttrs}/>${lightRig}</a:cell3D>`
 							}
 
 							// 6: Close cell Properties & Cell
@@ -1017,13 +1062,36 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					break
 
 				case SLIDE_OBJECT_TYPES.media:
-					if (slideItemObj.mtype === 'online') {
+					if (slideItemObj.mtype === 'audioCd' || slideItemObj.mtype === 'wav') {
+						// EG_Media is a choice, so these carry exactly one media element and no `p14:media`:
+						// `a:audioCd` references the listener's drive and `a:wavAudioFile` is the legacy
+						// embedded-WAV element, so neither has an embedded media part to point at
+						const coverRid = slideItemObj._coverRid ?? 2
+						strSlideXml += '<p:pic>'
+						strSlideXml += ' <p:nvPicPr>'
+						strSlideXml += `<p:cNvPr id="${coverRid}" name="${slideItemObj.options.objectName}"><a:hlinkClick r:id="" action="ppaction://media"/></p:cNvPr>`
+						strSlideXml += ' <p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr>'
+						if (slideItemObj.mtype === 'audioCd') {
+							const cd = slideItemObj.options.audioCd
+							strSlideXml += genXmlNvPr(slideItemObj.options, `<a:audioCd>${genXmlAudioCdTime('a:st', cd?.start)}${genXmlAudioCdTime('a:end', cd?.end)}</a:audioCd>`)
+						} else {
+							strSlideXml += genXmlNvPr(slideItemObj.options, `<a:wavAudioFile r:embed="rId${slideItemObj.mediaRid}"${slideItemObj.options.objectName ? ` name="${slideItemObj.options.objectName}"` : ''}/>`)
+						}
+						strSlideXml += ' </p:nvPicPr>'
+						strSlideXml += ` <p:blipFill><a:blip r:embed="rId${coverRid}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>`
+						strSlideXml += ' <p:spPr>'
+						strSlideXml += `  <a:xfrm${locationAttr}><a:off x="${x}" y="${y}"/><a:ext cx="${cx}" cy="${cy}"/></a:xfrm>`
+						strSlideXml += '  <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+						strSlideXml += ' </p:spPr>'
+						strSlideXml += '</p:pic>'
+					} else if (slideItemObj.mtype === 'online') {
+						const contentType = slideItemObj.options.contentType ? ` contentType="${encodeXmlEntities(slideItemObj.options.contentType)}"` : ''
 						strSlideXml += '<p:pic>'
 						strSlideXml += ' <p:nvPicPr>'
 						// IMPORTANT: <p:cNvPr id="" value is critical - if its not the same number as preview image `rId`, PowerPoint throws error!
 						strSlideXml += `<p:cNvPr id="${(slideItemObj.mediaRid ?? 0) + 2}" name="${slideItemObj.options.objectName}"/>`
 						strSlideXml += ' <p:cNvPicPr/>'
-						strSlideXml += genXmlNvPr(slideItemObj.options, `<a:videoFile r:link="rId${slideItemObj.mediaRid}"/>`)
+						strSlideXml += genXmlNvPr(slideItemObj.options, `<a:videoFile r:link="rId${slideItemObj.mediaRid}"${contentType}/>`)
 						strSlideXml += ' </p:nvPicPr>'
 						// NOTE: `blip` is diferent than videos; also there's no preview "p:extLst" above but exists in videos
 						strSlideXml += ` <p:blipFill><a:blip r:embed="rId${(slideItemObj.mediaRid ?? 0) + 1}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>` // NOTE: Preview image is required!
@@ -1035,6 +1103,7 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					} else {
 					// ECMA-376: audio uses `<a:audioFile>`, video uses `<a:videoFile>` under nvPr.
 						const mediaFileTag = slideItemObj.mtype === 'audio' ? 'a:audioFile' : 'a:videoFile'
+						const contentType = slideItemObj.options.contentType ? ` contentType="${encodeXmlEntities(slideItemObj.options.contentType)}"` : ''
 						strSlideXml += '<p:pic>'
 						strSlideXml += ' <p:nvPicPr>'
 						// IMPORTANT: <p:cNvPr id="" value is critical - if not the same number as preiew image rId, PowerPoint throws error!
@@ -1053,7 +1122,7 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 							: ''
 						strSlideXml += genXmlNvPr(
 							slideItemObj.options,
-							`<${mediaFileTag} r:link="rId${slideItemObj.mediaRid}"/>`,
+							`<${mediaFileTag} r:link="rId${slideItemObj.mediaRid}"${contentType}/>`,
 							narrationExt ? [mediaExt, narrationExt] : [mediaExt]
 						)
 						strSlideXml += ' </p:nvPicPr>'

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -75,6 +75,26 @@ test('contract: slide keeps text, shape, and table semantics', async () => {
 	assert.equal([...xml.matchAll(/<a:gridCol /g)].length, 2, 'table grid width changed')
 })
 
+test('contract: default tableStyles.xml stays an empty list with the built-in def GUID', async () => {
+	const xml = await readPart(zip, 'ppt/tableStyles.xml')
+	assert.ok(xml.trimEnd().endsWith('def="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"/>'), `default tableStyles.xml changed: ${xml}`)
+	assert.ok(!xml.includes('<a:tblStyle '), 'a default deck gained a table style')
+})
+
+test('contract: custom tableStyles write a:tblStyle and keep the built-in def GUID', async () => {
+	const STYLE_ID = '{A1B2C3D4-1111-2222-3333-444455556666}'
+	const pptx = new pptxgen()
+	pptx.tableStyles = [{ id: STYLE_ID, name: 'Contract Blue', firstRow: { bold: true, fill: { color: '4472C4' } } }]
+	pptx.addSlide().addTable([['H'], ['a']], { x: 1, y: 1, w: 4, tableStyleId: STYLE_ID, firstRow: true })
+	const stylesZip = await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer)
+	const xml = await readPart(stylesZip, 'ppt/tableStyles.xml')
+	assert.ok(xml.includes(`styleId="${STYLE_ID}"`) && xml.includes('styleName="Contract Blue"'), 'custom tblStyle missing')
+	assert.ok(xml.includes('def="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"'), '@def was repointed at a custom style')
+	assert.ok(xml.includes('<a:firstRow>') && xml.includes('b="on"'), 'firstRow text style missing')
+	const slide = await readPart(stylesZip, 'ppt/slides/slide1.xml')
+	assert.ok(slide.includes(`<a:tableStyleId>${STYLE_ID}</a:tableStyleId>`), 'table did not reference the custom style')
+})
+
 test('contract: library version is generated from package.json', () => {
 	const pptx = new pptxgen()
 	assert.match(pptx.version, /^\d+\.\d+\.\d+/)

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -3507,3 +3507,179 @@ test('OMML: malformed omml option throws instead of writing a corrupt package', 
 	const xml = await readPart(await writeZip(pptx3), 'ppt/slides/slide1.xml')
 	assert.ok(xml.includes('a&lt;b&amp;c'), 'valid OMML was rejected or mangled')
 })
+
+test('table cells emit diagonal borders, 3-D cells, overflow and keep rtlMode', async () => {
+	const pptx = new pptxgen()
+	pptx.addSlide().addTable(
+		[[
+			{ text: 'diag', options: { borderDiagonalDown: { color: 'FF0000', width: 2 }, borderDiagonalUp: { type: 'dash' }, cell3D: { material: 'clear' }, fill: { color: 'EEEEEE' } } },
+			{ text: '3d', options: { cell3D: { bevel: { preset: 'circle', width: 0.05, height: 0.05 }, material: 'metal', lightRig: { rig: 'threePt', dir: 't' } } } },
+			{ text: 'ovf', options: { horzOverflow: 'overflow', anchorCtr: true, textDirection: 'vert270' } },
+			{ text: 'mat', options: { cell3D: { material: 'matte' } } },
+		]],
+		{ x: 0.5, y: 0.5, w: 9, rtlMode: true }
+	)
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide1.xml')
+	const cells = xml.match(/<a:tcPr[\s\S]*?<\/a:tcPr>/g) ?? []
+	assert.equal(cells.length, 4, `expected four cells, got ${cells.length}`)
+
+	assert.ok(xml.includes('<a:tblPr rtl="1"'), 'a:tblPr@rtl missing - CT_TableProperties owns rtl, not a:tbl')
+	assert.ok(cells[0].includes('<a:lnTlToBr w="25400" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>'), `lnTlToBr wrong: ${cells[0]}`)
+	assert.ok(cells[0].includes('<a:lnBlToTr') && cells[0].includes('<a:prstDash val="sysDash"/>'), 'lnBlToTr missing or not dashed')
+	// CT_TableCellProperties fixes the child sequence, so the first cell carries every one of them
+	const seq = ['<a:lnL', '<a:lnR', '<a:lnT', '<a:lnB', '<a:lnTlToBr', '<a:lnBlToTr', '<a:cell3D', '<a:solidFill><a:srgbClr val="EEEEEE"/>'].map(tag => cells[0].indexOf(tag))
+	assert.ok(seq.every(idx => idx > -1), `a tcPr child is missing: ${seq.join(',')}`)
+	assert.deepEqual(seq, [...seq].sort((a, b) => a - b), `CT_TableCellProperties child order violated: ${seq.join(',')}`)
+
+	assert.ok(cells[1].includes('<a:cell3D prstMaterial="metal"><a:bevel w="45720" h="45720" prst="circle"/><a:lightRig rig="threePt" dir="t"/></a:cell3D>'), `cell3D wrong: ${cells[1]}`)
+	assert.ok(cells[1].indexOf('<a:cell3D') > cells[1].indexOf('<a:lnB'), 'cell3D must follow the border elements')
+	// `a:bevel` is required by CT_Cell3D, so it is written even when only the material is given
+	assert.ok(cells[3].includes('<a:cell3D prstMaterial="matte"><a:bevel/></a:cell3D>'), `material-only cell3D wrong: ${cells[3]}`)
+
+	assert.ok(cells[2].includes('vert="vert270"') && cells[2].includes('anchorCtr="1"') && cells[2].includes('horzOverflow="overflow"'), `cell attrs wrong: ${cells[2]}`)
+
+	// `rig` and `dir` are both required on CT_LightRig, so a partial rig is dropped
+	const partial = new pptxgen()
+	partial.addSlide().addTable([[{ text: 'y', options: { cell3D: { lightRig: { rig: 'threePt' } as never } } }]], { x: 1, y: 1, w: 4 })
+	const partialXml = await readPart(await writeZip(partial), 'ppt/slides/slide1.xml')
+	assert.ok(partialXml.includes('<a:cell3D><a:bevel/></a:cell3D>'), 'incomplete lightRig was emitted')
+
+	// a table that asks for none of it is unchanged: no new element, no new attribute
+	const bare = new pptxgen()
+	bare.addSlide().addTable([['a', 'b']], { x: 1, y: 1, w: 4 })
+	const bareXml = await readPart(await writeZip(bare), 'ppt/slides/slide1.xml')
+	for (const tag of ['<a:lnTlToBr', '<a:lnBlToTr', '<a:cell3D', 'horzOverflow=', 'anchorCtr=', 'rtl=']) {
+		assert.ok(!bareXml.includes(tag), `default table gained ${tag}`)
+	}
+})
+
+test('custom table style definitions reach ppt/tableStyles.xml', async () => {
+	const STYLE_ID = '{A1B2C3D4-1111-2222-3333-444455556666}'
+	const pptx = new pptxgen()
+	pptx.tableStyles = [
+		{
+			id: STYLE_ID,
+			name: 'NEOMA Blue',
+			// one style carrying every part, so the CT_TableStyle child order is actually exercised
+			wholeTable: { color: 'tx1', borders: { top: { color: '4472C4', width: 1 }, insideH: { color: 'D9D9D9', width: 0.5 } } },
+			band1H: { fill: { color: 'DEEAF6' } },
+			band2H: { fill: { color: 'FFFFFF' } },
+			band1V: { fill: { color: 'EEEEEE' } },
+			band2V: { fill: { color: 'DDDDDD' } },
+			lastCol: { bold: true },
+			firstCol: { bold: true },
+			lastRow: { bold: true, italic: false },
+			seCell: { fill: { color: '111111' } },
+			swCell: { fill: { color: '222222' } },
+			firstRow: { bold: true, color: 'FFFFFF', fill: { color: '4472C4' } },
+			neCell: { fill: { color: '333333' } },
+			nwCell: { fill: { color: '444444' } },
+		},
+		{ id: 'not-a-guid', name: 'Bad' },
+		{ id: '{A1B2C3D4-1111-2222-3333-444455556667}', name: '' },
+	]
+	pptx.addSlide().addTable([['H1', 'H2'], ['a', 'b']], { x: 1, y: 1, w: 6, tableStyleId: STYLE_ID, firstRow: true, bandRow: true })
+
+	const xml = await readPart(await writeZip(pptx), 'ppt/tableStyles.xml')
+	assert.ok(xml.includes(`<a:tblStyle styleId="${STYLE_ID}" styleName="NEOMA Blue">`), `tblStyle wrong: ${xml.slice(0, 300)}`)
+	// both attributes are required by CT_TableStyle, so a bad id or a missing name is dropped
+	assert.equal((xml.match(/<a:tblStyle /g) ?? []).length, 1, 'an invalid table style was emitted')
+	assert.ok(!xml.includes('not-a-guid'), 'a malformed style id reached the output')
+
+	// CT_TableStyle fixes this order, and it is neither alphabetical nor intuitive: lastCol before
+	// firstCol, and firstRow between swCell and neCell
+	const expected = ['wholeTbl', 'band1H', 'band2H', 'band1V', 'band2V', 'lastCol', 'firstCol', 'lastRow', 'seCell', 'swCell', 'firstRow', 'neCell', 'nwCell']
+	const emitted = (xml.match(/<a:(wholeTbl|band1H|band2H|band1V|band2V|lastCol|firstCol|lastRow|seCell|swCell|firstRow|neCell|nwCell)>/g) ?? []).map(tag => tag.slice(3, -1))
+	assert.deepEqual(emitted, expected, 'CT_TableStyle child order violated')
+
+	// `a:tcTxStyle` precedes `a:tcStyle`, and inside the cell style `a:tcBdr` precedes the fill
+	const firstRow = /<a:firstRow>[\s\S]*?<\/a:firstRow>/.exec(xml)?.[0] ?? ''
+	assert.ok(firstRow.includes('<a:tcTxStyle b="on"><a:srgbClr val="FFFFFF"/></a:tcTxStyle>'), `firstRow text style wrong: ${firstRow}`)
+	assert.ok(firstRow.indexOf('<a:tcTxStyle') < firstRow.indexOf('<a:tcStyle'), 'tcTxStyle must precede tcStyle')
+	assert.ok(firstRow.includes('<a:tcStyle><a:fill><a:solidFill><a:srgbClr val="4472C4"/></a:solidFill></a:fill></a:tcStyle>'), `firstRow fill wrong: ${firstRow}`)
+
+	const whole = /<a:wholeTbl>[\s\S]*?<\/a:wholeTbl>/.exec(xml)?.[0] ?? ''
+	assert.ok(whole.indexOf('<a:tcBdr>') < whole.indexOf('</a:tcStyle>'), 'tcBdr must sit inside tcStyle')
+	assert.ok(whole.includes('<a:top><a:ln w="12700"><a:solidFill><a:srgbClr val="4472C4"/></a:solidFill></a:ln></a:top>'), `border wrong: ${whole}`)
+	assert.ok(whole.includes('<a:insideH><a:ln w="6350">'), 'insideH border missing')
+
+	// `b`/`i` are ST_OnOffStyleType: an unset property is left to the theme, `false` is written as "off"
+	const lastRow = /<a:lastRow>[\s\S]*?<\/a:lastRow>/.exec(xml)?.[0] ?? ''
+	assert.ok(lastRow.includes('b="on"') && lastRow.includes('i="off"'), `lastRow on/off wrong: ${lastRow}`)
+	assert.ok(!(/<a:band1H>[\s\S]*?<\/a:band1H>/.exec(xml)?.[0] ?? '').includes('b='), 'an unset bold was written')
+
+	// `@def` is what a table with no `tableStyleId` inherits, so a custom style must not repoint it
+	assert.ok(xml.includes('def="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"'), '@def was repointed at a custom style')
+
+	// with no custom styles the part is the same self-closing stub as before
+	const bare = new pptxgen()
+	bare.addSlide().addTable([['a']], { x: 1, y: 1, w: 2 })
+	const bareXml = await readPart(await writeZip(bare), 'ppt/tableStyles.xml')
+	assert.ok(bareXml.trimEnd().endsWith('def="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"/>'), `default tableStyles.xml changed: ${bareXml}`)
+	assert.ok(!bareXml.includes('<a:tblStyle '), 'a default deck gained a table style')
+})
+
+test('media source elements - linked media, audioCd, wavAudioFile', async () => {
+	const MP4 = 'video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDE='
+	const WAV = 'audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA='
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addMedia({ type: 'video', data: MP4, x: 0.5, y: 0.5, w: 2, h: 1.5, isPhoto: true, userDrawn: true })
+	slide.addMedia({ type: 'video', link: 'C:/movies/clip.mp4', x: 3, y: 0.5, w: 2, h: 1.5, contentType: 'video/mp4' })
+	slide.addMedia({ type: 'audio', link: '/srv/audio/theme.mp3', x: 5.5, y: 0.5, w: 2, h: 1.5 })
+	slide.addMedia({ type: 'audioCd', audioCd: { start: { track: 1 }, end: { track: 1, time: 30 } }, x: 0.5, y: 2.5, w: 2, h: 1.5 })
+	slide.addMedia({ type: 'wav', data: WAV, x: 3, y: 2.5, w: 2, h: 1.5 })
+
+	const zip = await writeZip(pptx)
+	const xml = await readPart(zip, 'ppt/slides/slide1.xml')
+	const rels = await readPart(zip, 'ppt/slides/_rels/slide1.xml.rels')
+
+	// EG_Media is a choice: every media frame carries exactly one media element
+	const frames = (xml.match(/<p:nvPr[^>]*>[\s\S]*?<\/p:nvPr>/g) ?? []).filter(frame => /a:videoFile|a:audioFile|a:audioCd|a:wavAudioFile/.test(frame))
+	assert.equal(frames.length, 5, `expected five media frames, got ${frames.length}`)
+	for (const frame of frames) {
+		const kinds = (frame.match(/<a:(videoFile|audioFile|audioCd|wavAudioFile)\b/g) ?? []).length
+		assert.equal(kinds, 1, `EG_Media is a choice, but a frame carried ${kinds} media elements: ${frame}`)
+	}
+
+	// `p:nvPr` attributes default to false, so only the "on" case is written
+	assert.ok(xml.includes('<p:nvPr isPhoto="1" userDrawn="1">'), 'isPhoto/userDrawn missing')
+	assert.equal((xml.match(/<p:nvPr isPhoto=/g) ?? []).length, 1, 'isPhoto leaked onto other frames')
+
+	// linked media: same three-relationship shape, but external and with no part in the package
+	assert.ok(/<a:videoFile r:link="rId\d+" contentType="video\/mp4"\/>/.test(xml), `linked video wrong: ${frames[1]}`)
+	assert.ok(/<a:audioFile r:link="rId\d+"\/>/.test(xml), `linked audio wrong: ${frames[2]}`)
+	const relElements = rels.match(/<Relationship\b[^>]*\/>/g) ?? []
+	for (const target of ['C:/movies/clip.mp4', '/srv/audio/theme.mp3']) {
+		const matches = relElements.filter(rel => rel.includes(`Target="${target}"`))
+		assert.equal(matches.length, 2, `expected a video/audio and a media relationship for ${target}, got ${matches.length}`)
+		for (const rel of matches) assert.ok(rel.includes('TargetMode="External"'), `linked media relationship is not external: ${rel}`)
+	}
+	// nothing was written for the linked files, and no content type was declared for one
+	assert.ok(!Object.keys(zip.files).some(name => name.includes('clip.mp4') || name.includes('theme.mp3')), 'a part was written for linked media')
+	assert.ok(!(await readPart(zip, '[Content_Types].xml')).includes('Extension="mp3"'), 'a Default Extension was declared for a part that is never written')
+
+	// CT_AudioCD: `a:st`/`a:end` are required, `@track` is required, `@time` defaults to 0
+	assert.ok(xml.includes('<a:audioCd><a:st track="1"/><a:end track="1" time="30"/></a:audioCd>'), `audioCd wrong: ${frames[3]}`)
+	// CD audio references the drive, so it has no media relationship and no `p14:media`
+	assert.ok(!frames[3].includes('p14:media'), 'audioCd emitted a p14:media extension')
+
+	// `a:wavAudioFile` embeds via `r:embed` against an audio relationship, and has no `p14:media`
+	assert.ok(/<a:wavAudioFile r:embed="rId\d+" name="[^"]*"\/>/.test(frames[4]), `wavAudioFile wrong: ${frames[4]}`)
+	assert.ok(!frames[4].includes('p14:media'), 'wavAudioFile emitted a p14:media extension')
+	assert.ok(Object.keys(zip.files).some(name => name.endsWith('.wav')), 'the embedded WAV part is missing')
+	assert.ok((await readPart(zip, '[Content_Types].xml')).includes('Extension="wav" ContentType="audio/wav"'), 'the WAV content type is missing')
+
+	// audioCd requires both track numbers - addMedia throws rather than guessing
+	assert.throws(() => pptx.addSlide().addMedia({ type: 'audioCd', x: 1, y: 1, w: 1, h: 1 }), /audioCd\.start\.track/, 'audioCd without tracks did not throw')
+
+	// embedded media is unchanged: three relationships, an internal target, and a p14:media
+	const bare = new pptxgen()
+	bare.addSlide().addMedia({ type: 'video', data: MP4, x: 1, y: 1, w: 2, h: 1.5 })
+	const bareZip = await writeZip(bare)
+	const bareXml = await readPart(bareZip, 'ppt/slides/slide1.xml')
+	assert.ok(bareXml.includes('<p:nvPr>'), 'a default media frame gained an attribute')
+	assert.ok(/<a:videoFile r:link="rId\d+"\/>/.test(bareXml), `default video element changed: ${bareXml.match(/<a:videoFile[^>]*>/)?.[0] ?? ''}`)
+	assert.ok(bareXml.includes('p14:media') && /r:embed="rId\d+"/.test(bareXml), 'the embedded media extension changed')
+	assert.ok(!(await readPart(bareZip, 'ppt/slides/_rels/slide1.xml.rels')).includes('TargetMode="External"'), 'embedded media became external')
+})


### PR DESCRIPTION
## Summary
- Port DrawingML table cell completeness from Neoma `10b3eb25`: diagonal borders (`borderDiagonalDown` / `borderDiagonalUp`), `cell3D` (bevel/material/lightRig), and `a:tcPr` `horzOverflow` / `anchorCtr`. Existing `rtlMode`, `textDirection` / `vert`, and TRBL borders are unchanged.
- Port custom table styles from Neoma `5dfde092`: `pptx.tableStyles` writes real `a:tblStyle` entries into `ppt/tableStyles.xml`. Built-in `tableStyleId` GUIDs still work; `@def` stays the Medium Style 2 Accent 1 GUID. Empty decks still emit the self-closing stub.
- Port remaining media sources from Neoma `a0e8945c`: linked audio/video (`link` without `data`/`path`), `type: 'audioCd'`, `type: 'wav'` (`a:wavAudioFile`), plus `contentType`, `isPhoto`, and `userDrawn`. Existing audio/video/online and timing-tree playback options are unchanged.

## Test plan
- [x] `bun test test/issues.test.ts test/contracts.test.ts` (209 pass)
- [ ] Confirm a table with `tableStyleId` pointing at a custom `pptx.tableStyles` id bands/headers in PowerPoint
- [ ] Confirm linked media opens without embedding the file, and audioCd/wav frames open without repair

Made with [Cursor](https://cursor.com)