### PR TITLE
feat: port Neoma picture fills, remaining effects, recolor, and styleRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Picture fills on shapes and table cells via `fill: { type: 'image', image: { data|path, sizing, scale, alignment } }` (`a:blipFill` stretch/tile)
+- Remaining DrawingML effects: `fillOverlay`, preset shadows (`shadow: { type: 'preset', preset: 'shdw1'..'shdw20' }`), `effectDag`, image `alphaEffects`, and `fill: { type: 'group' }` (`a:grpFill`)
+- Image `recolor` (`ImageRecolorProps`) for duotone, grayscale, brightness/contrast, bi-level, and color-change on `a:blip` (does not replace SVG `fill` path recolor)
+- Shape/image `styleRef` emits `p:style` (`lnRef`/`fillRef`/`effectRef`/`fontRef`) so theme swaps can restyle objects
+- `slide.addConnector(options)` convenience that maps onto the existing connector fields, with optional `start`/`end` `objectName` glue
 - Text `vertOverflow` / `horzOverflow` emit ECMA-376 `a:bodyPr` overflow attrs so overflowing runs can clip instead of spilling out of the shape
 - Package-contract tests for opt-in `addFont` (Font parts, `application/x-fontdata`, Presentation font rels); default export embeds nothing
 - `pptx.slideShow` emits a spec-valid `p:showPr` with the required present/browse/kiosk choice, plus loop/narration/animation/timing flags

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/pptxgenjs-jsx": {
       "name": "pptxgenjs-plus-jsx",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "dependencies": {
         "pptxgenjs-plus": "file:../..",
       },
@@ -35,14 +35,14 @@
     },
     "packages/pptxgenjs-std": {
       "name": "pptxgenjs-plus-std",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "devDependencies": {
         "@types/node": "^26.2.0",
         "pptxgenjs-plus": "file:../..",
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "pptxgenjs-plus": "4.1.19",
+        "pptxgenjs-plus": "4.1.20",
       },
     },
   },

--- a/src/charts/utils.ts
+++ b/src/charts/utils.ts
@@ -85,7 +85,7 @@ export function genXmlErrBars (errorrate: number[], sheetCol: number, lastRow: n
  * `createShadowElement` has passed through the defaults-merge boundary.
  */
 const shadowBrand: unique symbol = Symbol('resolvedShadow')
-type ResolvedShadowProps = Required<ShadowProps> & { readonly [shadowBrand]: boolean }
+type ResolvedShadowProps = Omit<Required<ShadowProps>, 'preset'> & { preset?: ShadowProps['preset'], readonly [shadowBrand]: boolean }
 
 /**
  * Resolve boundary: merge user shadow options over the documented defaults and brand the result.

--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -10,6 +10,8 @@ export const EMU = 914400 // One (1) inch (OfficeXML measures in EMU (English Me
 export const ONEPT = 12700 // One (1) point (pt)
 export const CRLF = '\r\n' // AKA: Chr(13) & Chr(10)
 export const LAYOUT_IDX_SERIES_BASE = 2147483649
+/** ECMA-376 20.1.10.55 ST_RectAlignment — where a tiled picture fill starts */
+export const TILE_ALIGNMENTS = new Set(['tl', 't', 'tr', 'l', 'ctr', 'r', 'bl', 'b', 'br'])
 export const REGEX_HEX_COLOR = /^[0-9a-fA-F]{6}$/
 export const LINEH_MODIFIER = 1.67 // AKA: Golden Ratio Typography
 
@@ -25,7 +27,7 @@ export const DEF_FONT_TITLE_SIZE = 18
 export const DEF_PRES_LAYOUT = 'LAYOUT_16x9'
 export const DEF_PRES_LAYOUT_NAME = 'DEFAULT'
 export const DEF_SHAPE_LINE_COLOR = '333333'
-export const DEF_SHAPE_SHADOW = { type: 'outer', blur: 3, offset: 23000 / 12700, angle: 90, color: '000000', opacity: 0.35, rotateWithShape: true } satisfies Required<ShadowProps>
+export const DEF_SHAPE_SHADOW = { type: 'outer', blur: 3, offset: 23000 / 12700, angle: 90, color: '000000', opacity: 0.35, rotateWithShape: true } satisfies Omit<Required<ShadowProps>, 'preset'>
 export const DEF_SLIDE_BKGD = 'FFFFFF'
 export const DEF_SLIDE_MARGIN_IN: [number, number, number, number] = [0.5, 0.5, 0.5, 0.5] // TRBL-style
 export const DEF_TEXT_SHADOW = { type: 'outer', blur: 8, offset: 4, angle: 270, color: '000000', opacity: 0.75 }
@@ -209,6 +211,10 @@ export enum ShapeType {
 	'actionButtonSound' = 'actionButtonSound',
 	'arc' = 'arc',
 	'bentArrow' = 'bentArrow',
+	'bentConnector2' = 'bentConnector2',
+	'bentConnector3' = 'bentConnector3',
+	'bentConnector4' = 'bentConnector4',
+	'bentConnector5' = 'bentConnector5',
 	'bentUpArrow' = 'bentUpArrow',
 	'bevel' = 'bevel',
 	'blockArc' = 'blockArc',
@@ -232,6 +238,10 @@ export enum ShapeType {
 	'corner' = 'corner',
 	'cornerTabs' = 'cornerTabs',
 	'cube' = 'cube',
+	'curvedConnector2' = 'curvedConnector2',
+	'curvedConnector3' = 'curvedConnector3',
+	'curvedConnector4' = 'curvedConnector4',
+	'curvedConnector5' = 'curvedConnector5',
 	'curvedDownArrow' = 'curvedDownArrow',
 	'curvedLeftArrow' = 'curvedLeftArrow',
 	'curvedRightArrow' = 'curvedRightArrow',
@@ -352,6 +362,7 @@ export enum ShapeType {
 	'star6' = 'star6',
 	'star7' = 'star7',
 	'star8' = 'star8',
+	'straightConnector1' = 'straightConnector1',
 	'stripedRightArrow' = 'stripedRightArrow',
 	'sun' = 'sun',
 	'swooshArrow' = 'swooshArrow',
@@ -424,6 +435,10 @@ export enum SHAPE_TYPE {
 	ARC = 'arc',
 	BALLOON = 'wedgeRoundRectCallout',
 	BENT_ARROW = 'bentArrow',
+	BENT_CONNECTOR_2 = 'bentConnector2',
+	BENT_CONNECTOR_3 = 'bentConnector3',
+	BENT_CONNECTOR_4 = 'bentConnector4',
+	BENT_CONNECTOR_5 = 'bentConnector5',
 	BENT_UP_ARROW = 'bentUpArrow',
 	BEVEL = 'bevel',
 	BLOCK_ARC = 'blockArc',
@@ -440,6 +455,10 @@ export enum SHAPE_TYPE {
 	CORNER_TABS = 'cornerTabs',
 	CROSS = 'plus',
 	CUBE = 'cube',
+	CURVED_CONNECTOR_2 = 'curvedConnector2',
+	CURVED_CONNECTOR_3 = 'curvedConnector3',
+	CURVED_CONNECTOR_4 = 'curvedConnector4',
+	CURVED_CONNECTOR_5 = 'curvedConnector5',
 	CURVED_DOWN_ARROW = 'curvedDownArrow',
 	CURVED_DOWN_RIBBON = 'ellipseRibbon',
 	CURVED_LEFT_ARROW = 'curvedLeftArrow',
@@ -581,6 +600,7 @@ export enum SHAPE_TYPE {
 	STAR_6_POINT = 'star6',
 	STAR_7_POINT = 'star7',
 	STAR_8_POINT = 'star8',
+	STRAIGHT_CONNECTOR_1 = 'straightConnector1',
 	STRIPED_RIGHT_ARROW = 'stripedRightArrow',
 	SUN = 'sun',
 	SWOOSH_ARROW = 'swooshArrow',
@@ -618,6 +638,10 @@ export type SHAPE_NAME =
 	| 'actionButtonSound'
 	| 'arc'
 	| 'bentArrow'
+	| 'bentConnector2'
+	| 'bentConnector3'
+	| 'bentConnector4'
+	| 'bentConnector5'
 	| 'bentUpArrow'
 	| 'bevel'
 	| 'blockArc'
@@ -643,6 +667,10 @@ export type SHAPE_NAME =
 	| 'corner'
 	| 'cornerTabs'
 	| 'cube'
+	| 'curvedConnector2'
+	| 'curvedConnector3'
+	| 'curvedConnector4'
+	| 'curvedConnector5'
 	| 'curvedDownArrow'
 	| 'curvedLeftArrow'
 	| 'curvedRightArrow'
@@ -763,6 +791,7 @@ export type SHAPE_NAME =
 	| 'star6'
 	| 'star7'
 	| 'star8'
+	| 'straightConnector1'
 	| 'stripedRightArrow'
 	| 'sun'
 	| 'swooshArrow'

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -94,6 +94,12 @@ export interface BackgroundProps extends DataOrPathProps, ShapeFillProps {
 	 * @deprecated v3.6.0 - use `DataOrPathProps` instead - remove in v4.0.0
 	 */
 	src?: string
+	/**
+	 * Recolor and correction effects applied to a background image (`a:blip` children)
+	 * - distinct from SVG `fill` path recolor
+	 * @example { grayscale: true, brightness: -20 }
+	 */
+	recolor?: ImageRecolorProps
 }
 /**
  * Color in Hex format
@@ -385,6 +391,123 @@ export interface BlurProps {
 }
 
 /**
+ * Fill-overlay effect (`a:fillOverlay`, ECMA-376 Part 1 §20.1.8.29 CT_FillOverlayEffect)
+ * - blends a second fill over the shape's own fill
+ * - both properties are required by the schema, so a partial value is not emitted
+ */
+export interface FillOverlayProps {
+	/** Blend mode */
+	blend: 'over' | 'mult' | 'screen' | 'darken' | 'lighten'
+	/** The fill blended over the shape */
+	fill: ShapeFillProps
+}
+
+/**
+ * Composed effect graph (`a:effectDag`, ECMA-376 Part 1 §20.1.8.25 CT_EffectContainer)
+ * - `a:effectLst` and `a:effectDag` are alternatives in the schema, so setting this emits the
+ *   shape's effects inside `a:effectDag` instead of `a:effectLst`
+ */
+export interface EffectDagProps {
+	/**
+	 * Whether the contained effects apply to siblings or to the whole tree
+	 * @default sib
+	 */
+	type?: 'sib' | 'tree'
+}
+
+/**
+ * Recolor and correction effects applied to an image's `a:blip`
+ * - PowerPoint Picture Format > Color / Corrections
+ * - named `recolor` so it does not collide with SVG path `fill` recolor
+ * - artistic effects are not implemented (MS-ODRAWXML + required pre-rendered `a14:imgLayer`)
+ */
+export interface ImageRecolorProps {
+	/**
+	 * Map the image onto two colours (`a:duotone`)
+	 * - the schema requires exactly two, so anything else is dropped
+	 * @example ['000000', 'FFFFFF']
+	 */
+	duotone?: [Color, Color]
+	/** Convert to greyscale (`a:grayscl`) */
+	grayscale?: boolean
+	/**
+	 * Brightness, percent -100 to 100 (`a:lum@bright`)
+	 * @default 0
+	 */
+	brightness?: number
+	/**
+	 * Contrast, percent -100 to 100 (`a:lum@contrast`)
+	 * @default 0
+	 */
+	contrast?: number
+	/**
+	 * Reduce to two tones at this threshold, percent 0 to 100 (`a:biLevel@thresh`)
+	 */
+	blackWhiteThreshold?: number
+	/**
+	 * Replace one colour with another (`a:clrChange`)
+	 * - both colours are required by the schema
+	 */
+	colorChange?: {
+		from: Color
+		to: Color
+		/**
+		 * Whether the alpha channel takes part in the comparison (`@useA`)
+		 * @default true
+		 */
+		useAlpha?: boolean
+	}
+}
+
+/**
+ * Alpha (transparency) effects applied to an image's `a:blip`
+ * - allowed on `a:blip` and inside `a:effectDag`, not in `a:effectLst`
+ */
+export interface ImageAlphaEffectProps {
+	/**
+	 * Replace every alpha value with this one (`a:alphaRepl`)
+	 * - percent, 0 (fully transparent) to 100 (fully opaque)
+	 */
+	replace?: number
+	/** Invert the alpha channel (`a:alphaInv`) */
+	invert?: boolean
+	/** Force alpha values below 100% to fully transparent (`a:alphaFloor`) */
+	floor?: boolean
+	/** Force alpha values above 0% to fully opaque (`a:alphaCeiling`) */
+	ceiling?: boolean
+}
+
+/**
+ * Theme style references for a shape (`p:style`, ECMA-376 Part 1 §20.1.4.1.25 CT_ShapeStyle)
+ * - named `styleRef` because `style` is already used by chart gridlines
+ * - each index points into the matching list in the theme's `a:fmtScheme`, 1-based
+ */
+export interface ShapeStyleProps {
+	/** Index into the theme's `a:lnStyleLst` (1-based) */
+	line?: number
+	/** Index into the theme's `a:fillStyleLst` (1-based) */
+	fill?: number
+	/** Index into the theme's `a:effectStyleLst` (1-based) */
+	effect?: number
+	/**
+	 * Which of the theme's font collections the shape's text follows
+	 * @default none
+	 */
+	font?: 'major' | 'minor' | 'none'
+	/**
+	 * Colour the referenced line, fill and effect resolve the theme's `phClr` against
+	 * @default 'accent1'
+	 */
+	color?: Color
+	/**
+	 * Colour the referenced font resolves against
+	 * - defaults to `lt1` because a font sharing the fill's colour renders as invisible text
+	 * @default 'lt1'
+	 */
+	fontColor?: Color
+}
+
+/**
  * WordArt / preset text warp (`a:prstTxWarp@prst`, ECMA-376 `ST_TextShapeType`)
  * @see standards/ecma/part-22_drawingml-reference-material-drawingml-main.txt §5.1.12.76
  */
@@ -438,7 +561,12 @@ export interface ShadowProps {
 	 * shadow type
 	 * @default 'none'
 	 */
-	type: 'outer' | 'inner' | 'none'
+	type: 'outer' | 'inner' | 'none' | 'preset'
+	/**
+	 * Preset shadow name, required when `type` is `preset` (`a:prstShdw@prst`)
+	 * - PowerPoint's twenty built-in shadow presets
+	 */
+	preset?: 'shdw1' | 'shdw2' | 'shdw3' | 'shdw4' | 'shdw5' | 'shdw6' | 'shdw7' | 'shdw8' | 'shdw9' | 'shdw10' | 'shdw11' | 'shdw12' | 'shdw13' | 'shdw14' | 'shdw15' | 'shdw16' | 'shdw17' | 'shdw18' | 'shdw19' | 'shdw20'
 	/**
 	 * opacity (percent)
 	 * - range: 0.0-1.0
@@ -511,6 +639,46 @@ export interface ShapePatternProps {
 	bgColor?: Color
 }
 
+/**
+ * Picture fill (`a:blipFill`) for shapes and table cells
+ * - stretch (ECMA-376 20.1.8.56) or tile (20.1.8.58)
+ */
+export interface ShapeImageFillProps {
+	/**
+	 * Image data (base64), with a mime header
+	 * - one of `data` or `path` is required
+	 * @example 'image/png;base64,iVBORw0KGgo...'
+	 */
+	data?: string
+	/**
+	 * Image path or URL
+	 * - one of `data` or `path` is required
+	 */
+	path?: string
+	/**
+	 * How the image fills the shape
+	 * @default 'stretch'
+	 */
+	sizing?: 'stretch' | 'tile'
+	/**
+	 * `tile` only: scale applied to each tile (percent)
+	 * @default 100
+	 */
+	scale?: number
+	/**
+	 * `tile` only: where tiling starts
+	 * @default 'tl'
+	 */
+	alignment?: 'tl' | 't' | 'tr' | 'l' | 'ctr' | 'r' | 'bl' | 'b' | 'br'
+	/**
+	 * Whether the fill rotates with the shape
+	 * @default true
+	 */
+	rotateWithShape?: boolean
+	/** relationship id resolved when the object is created @internal */
+	_rId?: number
+}
+
 // used by: shape, table, text
 export interface ShapeFillProps {
 	/**
@@ -534,8 +702,10 @@ export interface ShapeFillProps {
 	 * - `'gradient'` — nested definition via `gradient` (linear + radial)
 	 * - `'linearGradient'` — flat sambauers/gradients API (`stops`/`angle`/… on this object)
 	 * - `'pattern'` — pattern fill via `pattern`
+	 * - `'image'` — picture fill via `image` (`a:blipFill`)
+	 * - `'group'` — inherit the parent group's fill (`a:grpFill`)
 	 */
-	type?: 'none' | 'solid' | 'gradient' | 'linearGradient' | 'pattern'
+	type?: 'none' | 'solid' | 'gradient' | 'linearGradient' | 'pattern' | 'image' | 'group'
 	/**
 	 * Gradient fill definition
 	 * - required when `type` is `'gradient'` (ignored otherwise)
@@ -548,6 +718,14 @@ export interface ShapeFillProps {
 	 * @example { type:'pattern', pattern:{ prst:'ltHorz', color:'000000', bgColor:'FFFFFF' } }
 	 */
 	pattern?: ShapePatternProps
+	/**
+	 * Picture fill definition
+	 * - required when `type` is `'image'`
+	 * @example { type:'image', image:{ data:'image/png;base64,iV[...]', sizing:'tile' } }
+	 */
+	image?: ShapeImageFillProps
+	/** relationship id for a picture fill without a nested `image` object @internal */
+	_rId?: number
 
 	/**
 	 * Flat linear-gradient stops (`type: 'linearGradient'`, sambauers/gradients)
@@ -716,6 +894,10 @@ export interface ShapeLineProps extends ShapeFillProps {
 	 * @example [50000] // mid bend for bentConnector3
 	 */
 	curveadjust?: number[]
+	/** `objectName` of the start shape (resolved to `sourceId` at emit) @internal */
+	_sourceName?: string
+	/** `objectName` of the end shape (resolved to `targetId` at emit) @internal */
+	_targetName?: string
 	// FUTURE: beginArrowSize (1-9)
 	// FUTURE: endArrowSize (1-9)
 
@@ -1164,6 +1346,31 @@ export interface ImageProps extends PositionProps, DataOrPathProps, ObjectNamePr
 	 */
 	blur?: BlurProps
 	/**
+	 * Fill blended over the image's own fill (`a:fillOverlay`)
+	 * @example { blend: 'mult', fill: { color: 'FF0000', transparency: 50 } }
+	 */
+	fillOverlay?: FillOverlayProps
+	/**
+	 * Emit the effects as a composed effect graph (`a:effectDag`) rather than an `a:effectLst`
+	 */
+	effectDag?: EffectDagProps
+	/**
+	 * Alpha (transparency) effects applied to the image itself (`a:blip`)
+	 * @example { invert: true }
+	 */
+	alphaEffects?: ImageAlphaEffectProps
+	/**
+	 * Recolor and correction effects applied to the image itself (`a:blip`)
+	 * - distinct from SVG path `fill` recolor
+	 * @example { grayscale: true, brightness: 20, contrast: -10 }
+	 */
+	recolor?: ImageRecolorProps
+	/**
+	 * Theme style references (`p:style`)
+	 * @example { fill: 1, line: 2, effect: 0, font: 'minor' }
+	 */
+	styleRef?: ShapeStyleProps
+	/**
 	 * Image sizing options
 	 */
 	sizing?: {
@@ -1338,6 +1545,11 @@ export interface GroupProps extends PositionProps, ObjectNameProps {
 	 * Group shadow (`a:effectLst` on `p:grpSpPr`)
 	 */
 	shadow?: ShadowProps
+	/**
+	 * Group fill (`EG_FillProperties` on `p:grpSpPr`)
+	 * - child shapes can inherit this with `fill: { type: 'group' }`
+	 */
+	fill?: ShapeFillProps
 	/** @internal child objects collected by `addGroup` */
 	_objects?: ISlideObject[]
 }
@@ -1351,6 +1563,51 @@ export interface Group {
 	addText(text: string | TextProps[], options?: TextPropsOptions): Group
 	addImage(options: ImageProps): Group
 	addGroup(options: GroupProps, build?: (group: Group) => void): Group
+	addConnector(options?: ConnectorProps): Group
+}
+
+/**
+ * Where a connector attaches to a shape (`a:stCxn`/`a:endCxn`)
+ * - maps onto existing `line.sourceId`/`targetId` via `objectName` at emit time
+ */
+export interface ConnectionProps {
+	/** `objectName` of the shape to glue to */
+	shape: string
+	/**
+	 * Which connection site on that shape
+	 * - a rectangle has 0 (top), 1 (left), 2 (bottom), 3 (right)
+	 * @default 0
+	 */
+	site?: number
+}
+
+/**
+ * Additive connector convenience (`slide.addConnector`)
+ * - maps onto `addShape` + `line.isConnector` / sourceId / targetId
+ */
+export interface ConnectorProps extends PositionProps, ObjectNameProps {
+	/**
+	 * Connector geometry
+	 * @default straightConnector1
+	 */
+	type?: 'line' | 'straightConnector1' | 'bentConnector2' | 'bentConnector3' | 'bentConnector4' | 'bentConnector5' | 'curvedConnector2' | 'curvedConnector3' | 'curvedConnector4' | 'curvedConnector5'
+	/** line formatting, including arrow heads */
+	line?: ShapeLineProps
+	/**
+	 * Rotation in degrees
+	 * @default 0
+	 */
+	rotate?: number
+	flipH?: boolean
+	flipV?: boolean
+	/** glue the start of the connector to a shape (`objectName`) */
+	start?: ConnectionProps
+	/** glue the end of the connector to a shape (`objectName`) */
+	end?: ConnectionProps
+	/** theme style references (`p:style`) */
+	styleRef?: ShapeStyleProps
+	shadow?: ShadowProps
+	fill?: ShapeFillProps
 }
 
 // shapes =========================================================================================
@@ -1466,6 +1723,20 @@ export interface ShapeProps extends PositionProps, ObjectNameProps, AppearOnClic
 	 * Blur effect (`a:blur` in shape `effectLst`)
 	 */
 	blur?: BlurProps
+	/**
+	 * Fill blended over the shape's own fill (`a:fillOverlay`)
+	 * @example { blend: 'mult', fill: { color: 'FF0000', transparency: 50 } }
+	 */
+	fillOverlay?: FillOverlayProps
+	/**
+	 * Emit the effects as a composed effect graph (`a:effectDag`) rather than an `a:effectLst`
+	 */
+	effectDag?: EffectDagProps
+	/**
+	 * Theme style references (`p:style`)
+	 * @example { fill: 1, line: 2, effect: 0, font: 'minor' }
+	 */
+	styleRef?: ShapeStyleProps
 
 	/**
 	 * @deprecated v3.3.0
@@ -1964,6 +2235,18 @@ export interface TextPropsOptions extends PositionProps, DataOrPathProps, TextBa
 	 * Blur effect (`a:blur` on the text shape)
 	 */
 	blur?: BlurProps
+	/**
+	 * Fill blended over the text shape's own fill (`a:fillOverlay`)
+	 */
+	fillOverlay?: FillOverlayProps
+	/**
+	 * Emit the effects as a composed effect graph (`a:effectDag`) rather than an `a:effectLst`
+	 */
+	effectDag?: EffectDagProps
+	/**
+	 * Theme style references (`p:style`)
+	 */
+	styleRef?: ShapeStyleProps
 	shape?: SHAPE_NAME
 	/**
 	 * Strikethrough style
@@ -2950,6 +3233,11 @@ export interface PresSlide extends SlideBaseProps {
 	 * Holds shapes, text, images, and nested groups — not tables, charts, or media.
 	 */
 	addGroup: (options: GroupProps, build?: (group: Group) => void) => PresSlide
+	/**
+	 * Connector shape (`p:cxnSp`). Additive convenience over `line.isConnector`.
+	 * Glue with `start`/`end` `objectName`s, or pass numeric `line.sourceId`/`targetId`.
+	 */
+	addConnector: (options?: ConnectorProps) => PresSlide
 	/**
 	 * WordArt: text with a warp (`presetShape` / `a:prstTxWarp`) and/or a gradient run fill.
 	 * Defaults to centered `textNoShape` (no transform) unless `options` override them.

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -28,6 +28,7 @@ import {
 	AddSlideProps,
 	BackgroundProps,
 	BorderProps,
+	ConnectorProps,
 	Group,
 	GroupProps,
 	IChartMulti,
@@ -461,7 +462,7 @@ function isSvgFillSource (data: string, path: string): boolean {
  * Register a table-cell image fill as slide media so `a:blipFill` can embed it
  * (Dominik-von-Burg PR 1461). Must run at addTable time so encodeSlideMediaRels sees the rels.
  */
-function registerTableCellImageFill (target: PresSlide, fill: ShapeFillProps | undefined): number | undefined {
+function registerTableCellImageFill (target: PresSlide | SlideLayout, fill: ShapeFillProps | undefined): number | undefined {
 	const data = typeof fill?.data === 'string' ? fill.data : ''
 	const path = typeof fill?.path === 'string' ? fill.path : ''
 	if (!data && !path) return undefined
@@ -516,7 +517,44 @@ function registerTableCellImageFill (target: PresSlide, fill: ShapeFillProps | u
 	return rId
 }
 
+function isStructuredImageFill (fill?: ShapeFillProps): boolean {
+	return !!fill && (fill.type === 'image' || !!fill.image)
+}
+
+/**
+ * Resolve a picture fill's image into a slide relationship.
+ * `genXmlColorSelection` is pure, so the rId has to be attached before XML is generated.
+ */
+export function resolveImageFill (target: PresSlide | SlideLayout, fill?: ShapeFillProps): void {
+	if (!fill || typeof fill !== 'object') return
+	if (!isStructuredImageFill(fill) && !(fill.data || fill.path) ) return
+	if (!isStructuredImageFill(fill) && (fill.color || (fill.type && fill.type !== 'image'))) return
+
+	const data = fill.image?.data ?? fill.data ?? ''
+	const path = fill.image?.path ?? fill.path ?? ''
+	if (!data && !path) {
+		console.warn('[pptxgenjs] `fill.type:"image"` requires `fill.image.data` or `fill.image.path` - fill ignored')
+		return
+	}
+	if (data && !data.toLowerCase().includes('base64,')) {
+		console.warn('[pptxgenjs] `fill.image.data` lacks a base64 header (ex: \'image/png;base64,iV[...]\') - fill ignored')
+		return
+	}
+
+	const rId = registerTableCellImageFill(target, { data, path })
+	if (!rId) return
+	if (fill.image) fill.image._rId = rId
+	else fill._rId = rId
+}
+
+function resolveObjectImageFills (target: PresSlide | SlideLayout, options: { fill?: ShapeFillProps, fillOverlay?: { fill?: ShapeFillProps } } | undefined): void {
+	if (!options) return
+	if (options.fill) resolveImageFill(target, options.fill)
+	if (options.fillOverlay?.fill) resolveImageFill(target, options.fillOverlay.fill)
+}
+
 export function addImageDefinition(target: PresSlide | SlideLayout, opt: ImageProps): void {
+	if (opt.fillOverlay?.fill) resolveImageFill(target, opt.fillOverlay.fill)
 	const newObject: ISlideObject = {
 		_type: SLIDE_OBJECT_TYPES.image,
 		text: undefined,
@@ -598,6 +636,11 @@ export function addImageDefinition(target: PresSlide | SlideLayout, opt: ImagePr
 		softEdge: opt.softEdge,
 		reflection: opt.reflection,
 		blur: opt.blur,
+		fillOverlay: opt.fillOverlay,
+		effectDag: opt.effectDag,
+		alphaEffects: opt.alphaEffects,
+		recolor: opt.recolor,
+		styleRef: opt.styleRef,
 		line: opt.line || imageBorderToLine(opt.border),
 		_sizeFromImage: !intWidth && !intHeight,
 		// addImage always writes x/y/w/h defaults, so remember which axes the caller actually set
@@ -1073,6 +1116,7 @@ function normalizeDeprecatedLineProps(
 export function addShapeDefinition(target: PresSlide | SlideLayout, shapeName: SHAPE_NAME, opts: ShapeProps): void {
 	const options = typeof opts === 'object' ? opts : {}
 	options.line = options.line || { type: 'none' }
+	resolveObjectImageFills(target, options)
 	const newObject: ISlideObject = {
 		_type: SLIDE_OBJECT_TYPES.text,
 		shape: shapeName || SHAPE_TYPE.RECTANGLE,
@@ -1109,6 +1153,8 @@ export function addShapeDefinition(target: PresSlide | SlideLayout, shapeName: S
 		targetAnchorPos: options.line.targetAnchorPos,
 		isConnector: options.line.isConnector || hasConnectorEnds,
 		curveadjust: options.line.curveadjust,
+		_sourceName: options.line._sourceName,
+		_targetName: options.line._targetName,
 	}
 	if (typeof options.line === 'object' && options.line.type !== 'none') options.line = newLineOpts
 
@@ -1185,7 +1231,8 @@ export function addTableDefinition(
 	// STEP 2: Transform `tableRows` into well-formatted TableCell's
 	// tableRows can be object or plain text array: `[{text:'cell 1'}, {text:'cell 2', options:{color:'ff0000'}}]` | `["cell 1", "cell 2"]`
 	const arrRows: TableCell[][] = []
-	const tableFillRid = registerTableCellImageFill(target, opt.fill)
+	if (isStructuredImageFill(opt.fill)) resolveImageFill(target, opt.fill)
+	const tableFillRid = isStructuredImageFill(opt.fill) ? undefined : registerTableCellImageFill(target, opt.fill)
 	tableRows.forEach(row => {
 		const newRow: TableCell[] = []
 
@@ -1234,9 +1281,13 @@ export function addTableDefinition(
 					}
 				})
 
-				const fillRid = registerTableCellImageFill(target, cellOpts.fill) ??
-					(cellOpts.fill ? undefined : tableFillRid)
-				if (fillRid) cellOpts._fillRid = fillRid
+				if (isStructuredImageFill(cellOpts.fill)) {
+					resolveImageFill(target, cellOpts.fill)
+				} else {
+					const fillRid = registerTableCellImageFill(target, cellOpts.fill) ??
+						(cellOpts.fill ? undefined : tableFillRid)
+					if (fillRid) cellOpts._fillRid = fillRid
+				}
 
 				// LAST:
 				newRow.push(newCell)
@@ -1431,6 +1482,7 @@ export function addTableDefinition(
  * @since: 1.0.0
  */
 export function addTextDefinition(target: PresSlide | SlideLayout, text: TextProps[], opts: TextPropsOptions, isPlaceholder: boolean): void {
+	resolveObjectImageFills(target, opts)
 	const newObject: ISlideObject = {
 		_type: isPlaceholder ? SLIDE_OBJECT_TYPES.placeholder : SLIDE_OBJECT_TYPES.text,
 		shape: (opts?.shape) || SHAPE_TYPE.RECTANGLE,
@@ -1730,6 +1782,7 @@ function makeGroupCollector (parent: PresSlide): PresSlide {
  * Child coordinates are relative to the group origin (`chOff` 0,0 / `chExt` = group size).
  */
 export function addGroupDefinition (target: PresSlide, opts: GroupProps, objects: ISlideObject[]): ISlideObject {
+	if (opts.fill) resolveImageFill(target, opts.fill)
 	const groupCount = target._slideObjects.filter(obj => obj._type === SLIDE_OBJECT_TYPES.group).length
 	const newObject: ISlideObject = {
 		_type: SLIDE_OBJECT_TYPES.group,
@@ -1740,6 +1793,7 @@ export function addGroupDefinition (target: PresSlide, opts: GroupProps, objects
 			h: opts.h ?? 1,
 			rotate: opts.rotate ?? 0,
 			shadow: opts.shadow ? correctShadowOptions(opts.shadow) : undefined,
+			fill: opts.fill,
 			objectName: opts.objectName ? encodeXmlEntities(opts.objectName) : `Group ${groupCount + 1}`,
 		},
 		_objects: objects,
@@ -1777,6 +1831,51 @@ export function createGroupBuilder (parent: PresSlide, objects: ISlideObject[]):
 			objects.push(...collector._slideObjects)
 			return builder
 		},
+		addConnector (options) {
+			const collector = makeGroupCollector(parent)
+			addConnectorDefinition(collector, options ?? {})
+			objects.push(...collector._slideObjects)
+			return builder
+		},
 	}
 	return builder
+}
+
+const CONNECTOR_PRESETS = new Set([
+	'line', 'straightConnector1',
+	'bentConnector2', 'bentConnector3', 'bentConnector4', 'bentConnector5',
+	'curvedConnector2', 'curvedConnector3', 'curvedConnector4', 'curvedConnector5',
+])
+
+/**
+ * Additive connector convenience: maps onto `addShape` + `line.isConnector`.
+ * `start`/`end` `objectName`s are resolved to `sourceId`/`targetId` at emit time.
+ */
+export function addConnectorDefinition (target: PresSlide | SlideLayout, opt: ConnectorProps): void {
+	const requested = opt.type && CONNECTOR_PRESETS.has(opt.type) ? opt.type : 'straightConnector1'
+	const shapeName = (requested === 'line' ? SHAPE_TYPE.LINE : requested) as SHAPE_NAME
+	const line: ShapeLineProps = {
+		...(opt.line ?? {}),
+		isConnector: true,
+		sourceId: opt.line?.sourceId,
+		targetId: opt.line?.targetId,
+		sourceAnchorPos: opt.start?.site ?? opt.line?.sourceAnchorPos,
+		targetAnchorPos: opt.end?.site ?? opt.line?.targetAnchorPos,
+		_sourceName: opt.start?.shape,
+		_targetName: opt.end?.shape,
+	}
+	addShapeDefinition(target, shapeName, {
+		x: opt.x,
+		y: opt.y,
+		w: opt.w,
+		h: opt.h,
+		objectName: opt.objectName,
+		rotate: opt.rotate,
+		flipH: opt.flipH,
+		flipV: opt.flipV,
+		fill: opt.fill,
+		shadow: opt.shadow,
+		styleRef: opt.styleRef,
+		line,
+	})
 }

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -4,8 +4,8 @@
 
 import { parseXml } from '@rgrove/parse-xml'
 
-import { EMU, REGEX_HEX_COLOR, DEF_FONT_COLOR, DEF_TEXT_GLOW, ONEPT, SchemeColor, SCHEME_COLORS } from './core-enums'
-import { PresLayout, TextGlowProps, PresSlide, SlideLayout, ShapeFillProps, Color, ShapeLineProps, Coord, ShadowProps, ShapeGradientProps, ShapePatternProps, ModifiedThemeColor, ThemeProps, HexColor } from './core-interfaces'
+import { EMU, REGEX_HEX_COLOR, DEF_FONT_COLOR, DEF_TEXT_GLOW, ONEPT, SchemeColor, SCHEME_COLORS, TILE_ALIGNMENTS } from './core-enums'
+import { PresLayout, TextGlowProps, PresSlide, SlideLayout, ShapeFillProps, Color, ShapeLineProps, Coord, ShadowProps, ShapeGradientProps, ShapePatternProps, ShapeImageFillProps, ModifiedThemeColor, ThemeProps, HexColor } from './core-interfaces'
 
 /** debug namespace, used for both the log prefix and the `NODE_DEBUG` section name */
 const DEBUG_NS = 'pptxgenjs'
@@ -614,6 +614,25 @@ function createPatternFillElement (pattern: ShapePatternProps | undefined, fallb
 }
 
 /**
+ * Create a DrawingML `a:blipFill` for a picture fill (ECMA-376 20.1.8.14)
+ * - the image relationship is resolved when the object is created
+ */
+function createImageFillElement (image: ShapeImageFillProps, rId: number): string {
+	let mode = '<a:stretch><a:fillRect/></a:stretch>'
+	if (image.sizing === 'tile') {
+		const scale = typeof image.scale === 'number' && isFinite(image.scale) && image.scale > 0 ? Math.round(image.scale * 1000) : 100000
+		const rawAlgn = image.alignment ?? 'tl'
+		const algn = TILE_ALIGNMENTS.has(rawAlgn) ? rawAlgn : 'tl'
+		if (image.alignment && !TILE_ALIGNMENTS.has(image.alignment)) {
+			console.warn(`[pptxgenjs] unknown tile alignment "${String(image.alignment)}" - "tl" used instead`)
+		}
+		mode = `<a:tile tx="0" ty="0" sx="${scale}" sy="${scale}" flip="none" algn="${algn}"/>`
+	}
+
+	return `<a:blipFill rotWithShape="${image.rotateWithShape === false ? '0' : '1'}"><a:blip r:embed="rId${rId}"/>${mode}</a:blipFill>`
+}
+
+/**
  * Create color selection
  * @param {Color | ShapeFillProps | ShapeLineProps} props fill props
  * @returns XML string
@@ -632,6 +651,7 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 			colorVal = props
 		} else {
 			if (props.type) fillType = props.type
+			else if (props.image?._rId || props._rId) fillType = 'image'
 			if (props.color) colorVal = props.color
 			if (props.alpha) internalElements += `<a:alpha val="${Math.round((100 - props.alpha) * 1000)}"/>` // DEPRECATED: @deprecated v3.3.0
 			if (props.transparency) internalElements += `<a:alpha val="${Math.round((100 - props.transparency) * 1000)}"/>`
@@ -654,6 +674,19 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 					typeof props === 'string' || isModifiedThemeColor(props) ? undefined : props.pattern,
 					typeof colorVal === 'string' ? colorVal : String(colorVal.baseColor),
 				)
+				break
+			case 'image': {
+				const image = typeof props === 'string' || isModifiedThemeColor(props) ? undefined : props.image
+				const rId = image?._rId ?? (typeof props === 'string' || isModifiedThemeColor(props) ? undefined : props._rId)
+				if (rId) {
+					outText += createImageFillElement(image ?? {}, rId)
+				} else {
+					console.warn('[pptxgenjs] `fill.type:"image"` requires `fill.image.data` or `fill.image.path` - fill omitted')
+				}
+				break
+			}
+			case 'group':
+				outText += '<a:grpFill/>'
 				break
 			case 'none':
 				outText += '<a:noFill/>'
@@ -690,8 +723,8 @@ export function correctShadowOptions (ShadowProps: ShadowProps): ShadowProps | u
 	ShadowProps = { ...ShadowProps }
 
 	// OPT: `type`
-	if (ShadowProps.type !== 'outer' && ShadowProps.type !== 'inner' && ShadowProps.type !== 'none') {
-		console.warn('Warning: shadow.type options are `outer`, `inner` or `none`.')
+	if (ShadowProps.type !== 'outer' && ShadowProps.type !== 'inner' && ShadowProps.type !== 'none' && ShadowProps.type !== 'preset') {
+		console.warn('Warning: shadow.type options are `outer`, `inner`, `preset` or `none`.')
 		ShadowProps.type = 'outer'
 	}
 

--- a/src/pptxgen.ts
+++ b/src/pptxgen.ts
@@ -547,6 +547,7 @@ export default class PptxGenJS implements IPresentationProps {
 			addTable: notOnMaster,
 			addText: notOnMaster,
 			addGroup: notOnMaster,
+			addConnector: notOnMaster,
 			addWordArt: notOnMaster,
 			addTransition: notOnMaster,
 			addAnimation: notOnMaster,

--- a/src/slide.ts
+++ b/src/slide.ts
@@ -7,6 +7,7 @@ import {
 	AddSlideProps,
 	AnimationConfig,
 	BackgroundProps,
+	ConnectorProps,
 	Group,
 	GroupProps,
 	CommentProps,
@@ -59,6 +60,8 @@ function cloneTextRunOpts (options?: TextPropsOptions): TextPropsOptions | undef
 	delete runOpts.reflection
 	delete runOpts.shadow
 	delete runOpts.blur
+	delete runOpts.fillOverlay
+	delete runOpts.effectDag
 	return runOpts
 }
 
@@ -253,6 +256,16 @@ export default class Slide {
 		const children: ISlideObject[] = options._objects ? [...options._objects] : []
 		if (build) build(genObj.createGroupBuilder(this, children))
 		genObj.addGroupDefinition(this, cloneOpts(options), children)
+		return this
+	}
+
+	/**
+	 * Add a connector (`p:cxnSp`). Additive convenience over `line.isConnector`.
+	 * Glue with `start`/`end` `objectName`s, or pass numeric `line.sourceId`/`targetId`.
+	 * @example slide.addConnector({ type: 'straightConnector1', start: { shape: 'BoxA', site: 3 }, end: { shape: 'BoxB', site: 1 } })
+	 */
+	addConnector(options?: ConnectorProps): Slide {
+		genObj.addConnectorDefinition(this, cloneOpts(options ?? {}))
 		return this
 	}
 

--- a/src/xml/slide.ts
+++ b/src/xml/slide.ts
@@ -15,6 +15,10 @@ import {
 import {
 	BlurProps,
 	Coord,
+	EffectDagProps,
+	FillOverlayProps,
+	ImageAlphaEffectProps,
+	ImageRecolorProps,
 	ISlideObject,
 	ObjectOptions,
 	PresLayout,
@@ -23,6 +27,7 @@ import {
 	SectionProps,
 	ShadowProps,
 	ShapeLineProps,
+	ShapeStyleProps,
 	SlideLayout,
 	SoftEdgeProps,
 	TableCell,
@@ -159,15 +164,22 @@ function genXmlLine (line: ShapeLineProps): string {
  * @note pure - unit conversion must NOT mutate the caller's options (issue #20)
  */
 function genXmlShadowElement (shadow: ShadowProps): string {
-	const type = shadow.type === 'inner' ? 'inner' : 'outer'
-	const blur = valToPts(shadow.blur ?? 8)
 	const offset = valToPts(shadow.offset ?? 4)
 	const angle = Math.round((shadow.angle ?? 270) * 60000)
 	const opacity = Math.round((shadow.opacity ?? 0.75) * 100000)
 	const color = shadow.color || DEF_TEXT_SHADOW.color
+	const colorXml = `<a:srgbClr val="${color}"><a:alpha val="${opacity}"/></a:srgbClr>`
+
+	if (shadow.type === 'preset') {
+		if (!shadow.preset) return ''
+		return `<a:prstShdw prst="${shadow.preset}" dist="${offset}" dir="${angle}">${colorXml}</a:prstShdw>`
+	}
+
+	const type = shadow.type === 'inner' ? 'inner' : 'outer'
+	const blur = valToPts(shadow.blur ?? 8)
 	const attrs = type === 'outer' ? 'sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0"' : ''
 
-	return `<a:${type}Shdw ${attrs} blurRad="${blur}" dist="${offset}" dir="${angle}"><a:srgbClr val="${color}"><a:alpha val="${opacity}"/></a:srgbClr></a:${type}Shdw>`
+	return `<a:${type}Shdw ${attrs} blurRad="${blur}" dist="${offset}" dir="${angle}">${colorXml}</a:${type}Shdw>`
 }
 
 /**
@@ -197,6 +209,8 @@ export type ShapeEffectLstOptions = {
 	softEdge?: SoftEdgeProps
 	reflection?: ReflectionProps
 	blur?: BlurProps
+	fillOverlay?: FillOverlayProps
+	effectDag?: EffectDagProps
 }
 
 /**
@@ -209,32 +223,130 @@ function genXmlBlurElement (blur: BlurProps): string {
 }
 
 /**
- * Create the shape/image `a:effectLst` block (blur + glow + shadow + reflection + softEdge).
- * Child order follows ECMA-376 `CT_EffectList`: blur, glow, innerShdw, outerShdw, reflection, softEdge.
+ * Create `a:fillOverlay` (CT_FillOverlayEffect). `@blend` and a fill are both required.
+ */
+function genXmlFillOverlayElement (overlay: FillOverlayProps): string {
+	if (!overlay.blend || !overlay.fill) return ''
+	const fill = genXmlColorSelection(overlay.fill)
+	return fill ? `<a:fillOverlay blend="${overlay.blend}">${fill}</a:fillOverlay>` : ''
+}
+
+/**
+ * Create the shape/image effect block (blur + fillOverlay + glow + shadow + reflection + softEdge).
+ * Child order follows ECMA-376 `CT_EffectList`: blur, fillOverlay, glow, innerShdw, outerShdw,
+ * prstShdw, reflection, softEdge. `effectDag` replaces `effectLst` (EG_EffectProperties choice).
  * @note pure - unit conversion must NOT be written back to the caller's options object (issue #20)
  */
 function genXmlEffectLst (opts: ShapeEffectLstOptions): string {
 	const parts: string[] = []
 
 	if (opts.blur && typeof opts.blur.radius === 'number') parts.push(genXmlBlurElement(opts.blur))
+	if (opts.fillOverlay) {
+		const overlay = genXmlFillOverlayElement(opts.fillOverlay)
+		if (overlay) parts.push(overlay)
+	}
 
 	const resolvedGlow = resolveGlowOptions(opts.glow)
 	if (resolvedGlow) parts.push(createGlowElement(resolvedGlow))
 
 	const shadow = opts.shadow
 	if (shadow && shadow.type !== 'none') {
-		parts.push(genXmlShadowElement(shadow))
+		const shadowXml = genXmlShadowElement(shadow)
+		if (shadowXml) parts.push(shadowXml)
 	}
 
 	if (opts.reflection) parts.push(genXmlReflectionElement(opts.reflection))
 	if (opts.softEdge) parts.push(genXmlSoftEdgeElement(opts.softEdge))
 
 	if (!parts.length) return ''
-	return `<a:effectLst>${parts.join('')}</a:effectLst>`
+	const xml = parts.join('')
+	if (opts.effectDag) return `<a:effectDag type="${opts.effectDag.type === 'tree' ? 'tree' : 'sib'}">${xml}</a:effectDag>`
+	return `<a:effectLst>${xml}</a:effectLst>`
+}
+
+/**
+ * Theme style references for a shape (`p:style`).
+ * CT_ShapeStyle requires all four children; an unset property references nothing (`idx="0"` / `none`).
+ */
+function genXmlShapeStyle (style?: ShapeStyleProps): string {
+	if (!style) return ''
+
+	let color = style.color ?? 'accent1'
+	if (color === 'phClr') {
+		console.warn('[pptxgenjs] `styleRef.color` cannot be `phClr` - it is the placeholder a theme reference resolves, not a color. Using `accent1`.')
+		color = 'accent1'
+	}
+	let fontColor = style.fontColor
+	if (fontColor === 'phClr') {
+		console.warn('[pptxgenjs] `styleRef.fontColor` cannot be `phClr` - using `lt1`.')
+		fontColor = undefined
+	}
+
+	const idx = (value?: number): number => (typeof value === 'number' && isFinite(value) && value > 0 ? Math.round(value) : 0)
+	const matrixColor = createColorElement(color)
+	const fontColorXml = fontColor ? createColorElement(fontColor) : '<a:schemeClr val="lt1"/>'
+
+	return (
+		'<p:style>' +
+		`<a:lnRef idx="${idx(style.line)}">${matrixColor}</a:lnRef>` +
+		`<a:fillRef idx="${idx(style.fill)}">${matrixColor}</a:fillRef>` +
+		`<a:effectRef idx="${idx(style.effect)}">${matrixColor}</a:effectRef>` +
+		`<a:fontRef idx="${style.font === 'major' || style.font === 'minor' ? style.font : 'none'}">${fontColorXml}</a:fontRef>` +
+		'</p:style>'
+	)
+}
+
+/**
+ * Recolor and correction effects for an image's `a:blip`.
+ */
+function genXmlBlipRecolor (recolor?: ImageRecolorProps): string {
+	if (!recolor) return ''
+	let xml = ''
+
+	if (Array.isArray(recolor.duotone)) {
+		if (recolor.duotone.length === 2) xml += `<a:duotone>${recolor.duotone.map(color => createColorElement(color)).join('')}</a:duotone>`
+		else console.warn(`[pptxgenjs] image \`recolor.duotone\` needs exactly two colors - ${recolor.duotone.length} given, effect omitted`)
+	}
+	if (recolor.grayscale === true) xml += '<a:grayscl/>'
+
+	const bright = typeof recolor.brightness === 'number' && isFinite(recolor.brightness) ? Math.round(Math.min(100, Math.max(-100, recolor.brightness)) * 1000) : undefined
+	const contrast = typeof recolor.contrast === 'number' && isFinite(recolor.contrast) ? Math.round(Math.min(100, Math.max(-100, recolor.contrast)) * 1000) : undefined
+	if (bright !== undefined || contrast !== undefined) {
+		xml += `<a:lum${bright !== undefined ? ` bright="${bright}"` : ''}${contrast !== undefined ? ` contrast="${contrast}"` : ''}/>`
+	}
+
+	if (typeof recolor.blackWhiteThreshold === 'number' && isFinite(recolor.blackWhiteThreshold)) {
+		xml += `<a:biLevel thresh="${Math.round(Math.min(100, Math.max(0, recolor.blackWhiteThreshold)) * 1000)}"/>`
+	}
+
+	if (recolor.colorChange) {
+		if (recolor.colorChange.from && recolor.colorChange.to) {
+			const useA = recolor.colorChange.useAlpha === false ? ' useA="0"' : ''
+			xml += `<a:clrChange${useA}><a:clrFrom>${createColorElement(recolor.colorChange.from)}</a:clrFrom><a:clrTo>${createColorElement(recolor.colorChange.to)}</a:clrTo></a:clrChange>`
+		} else {
+			console.warn('[pptxgenjs] image `recolor.colorChange` needs both `from` and `to` - effect omitted')
+		}
+	}
+
+	return xml
+}
+
+/**
+ * Alpha + recolor effects for an image's `a:blip`.
+ */
+function genXmlBlipEffects (transparency?: number, alpha?: ImageAlphaEffectProps, recolor?: ImageRecolorProps): string {
+	let xml = transparency ? `<a:alphaModFix amt="${Math.round((100 - transparency) * 1000)}"/>` : ''
+	xml += genXmlBlipRecolor(recolor)
+	if (!alpha) return xml
+	if (typeof alpha.replace === 'number' && isFinite(alpha.replace)) xml += `<a:alphaRepl a="${Math.round(Math.min(100, Math.max(0, alpha.replace)) * 1000)}"/>`
+	if (alpha.invert === true) xml += '<a:alphaInv/>'
+	if (alpha.floor === true) xml += '<a:alphaFloor/>'
+	if (alpha.ceiling === true) xml += '<a:alphaCeiling/>'
+	return xml
 }
 
 /** Shape id → layout box used to auto-size connectors (ZentoSoft) */
-type ShapeIdCoord = { id: number, position: { x?: Coord, y?: Coord, w?: Coord, h?: Coord } }
+type ShapeIdCoord = { id: number, objectName?: string, position: { x?: Coord, y?: Coord, w?: Coord, h?: Coord } }
 
 function findShapeCoord (list: ShapeIdCoord[], id: number | undefined): ShapeIdCoord | undefined {
 	if (id == null) return undefined
@@ -270,6 +382,19 @@ function anchorPointInches (
  * When a connector references shapes with numeric inch positions + rect anchors,
  * compute the line's x/y/w/h and flip flags (ZentoSoft auto-layout).
  */
+function resolveConnectorObjectNames (line: ShapeLineProps, coordinates: ShapeIdCoord[]): void {
+	if (line._sourceName) {
+		const found = coordinates.find(item => item.objectName === line._sourceName)
+		if (found) line.sourceId = found.id
+		else console.warn(`[pptxgenjs] connector start shape "${line._sourceName}" not found - attachment omitted`)
+	}
+	if (line._targetName) {
+		const found = coordinates.find(item => item.objectName === line._targetName)
+		if (found) line.targetId = found.id
+		else console.warn(`[pptxgenjs] connector end shape "${line._targetName}" not found - attachment omitted`)
+	}
+}
+
 function applyConnectorAutoLayout (
 	line: ShapeLineProps,
 	coordinates: ShapeIdCoord[],
@@ -441,7 +566,8 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 
 	// STEP 1: Add background color/image (ensure only a single `<p:bg>` tag is created, ex: when master-baskground has both `color` and `path`)
 	if (slide._bkgdImgRid) {
-		strSlideXml += `<p:bg><p:bgPr><a:blipFill dpi="0" rotWithShape="1"><a:blip r:embed="rId${slide._bkgdImgRid}"><a:lum/></a:blip><a:srcRect/><a:stretch><a:fillRect/></a:stretch></a:blipFill><a:effectLst/></p:bgPr></p:bg>`
+		const bkgdEffects = genXmlBlipRecolor(slide.background?.recolor)
+		strSlideXml += `<p:bg><p:bgPr><a:blipFill dpi="0" rotWithShape="1"><a:blip r:embed="rId${slide._bkgdImgRid}">${bkgdEffects || '<a:lum/>'}</a:blip><a:srcRect/><a:stretch><a:fillRect/></a:stretch></a:blipFill><a:effectLst/></p:bgPr></p:bg>`
 	} else if (
 		slide.background?.color ||
 		(slide.background?.type === 'gradient' && slide.background.gradient) ||
@@ -479,6 +605,7 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 			slideItemObj.options.sId = shapeId
 			shapeCoordinates.push({
 				id: shapeId,
+				objectName: slideItemObj.options.objectName,
 				position: {
 					x: slideItemObj.options.x,
 					y: slideItemObj.options.y,
@@ -504,6 +631,9 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 			}
 
 			// A: Geometry — connectors may auto-size from source/target shape boxes (ZentoSoft)
+			if (slideItemObj.options.line?.isConnector) {
+				resolveConnectorObjectNames(slideItemObj.options.line, shapeCoordinates)
+			}
 			const connectorLayout =
 				slideItemObj.options.line?.isConnector
 					? applyConnectorAutoLayout(slideItemObj.options.line, shapeCoordinates, slide._presLayout)
@@ -830,7 +960,12 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					if (isConnector) {
 						strSlideXml += '<p:cxnSp>'
 						strSlideXml += `<p:nvCxnSpPr><p:cNvPr id="${shapeId}" name="${slideItemObj.options.objectName}"></p:cNvPr>`
-						strSlideXml += `<p:cNvCxnSpPr><a:stCxn id="${slideItemObj.options.line?.sourceId}" idx="${slideItemObj.options.line?.sourceAnchorPos ?? 0}"/><a:endCxn id="${slideItemObj.options.line?.targetId}" idx="${slideItemObj.options.line?.targetAnchorPos ?? 0}"/></p:cNvCxnSpPr>`
+						const stId = slideItemObj.options.line?.sourceId
+						const endId = slideItemObj.options.line?.targetId
+						strSlideXml += '<p:cNvCxnSpPr>'
+						if (stId != null) strSlideXml += `<a:stCxn id="${stId}" idx="${slideItemObj.options.line?.sourceAnchorPos ?? 0}"/>`
+						if (endId != null) strSlideXml += `<a:endCxn id="${endId}" idx="${slideItemObj.options.line?.targetAnchorPos ?? 0}"/>`
+						strSlideXml += '</p:cNvCxnSpPr>'
 						strSlideXml += `${genXmlNvPr(slideItemObj.options, '', [nvPrModIdExt(slideItemObj.options.modId)])}</p:nvCxnSpPr><p:spPr>`
 					} else {
 						strSlideXml += '<p:sp>'
@@ -885,12 +1020,14 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					}
 
 					// Option: FILL
-					strSlideXml += slideItemObj.options.fill ? genXmlColorSelection(slideItemObj.options.fill) : '<a:noFill/>'
+					// With a fillRef and no explicit fill, omit the fill element so the theme inherits
+					if (slideItemObj.options.fill) strSlideXml += genXmlColorSelection(slideItemObj.options.fill)
+					else if (!slideItemObj.options.styleRef?.fill) strSlideXml += '<a:noFill/>'
 
 					// shape Type: LINE: line color
 					if (slideItemObj.options.line) strSlideXml += genXmlLine(slideItemObj.options.line)
 
-					// EFFECTS: shadow / glow / softEdge / reflection
+					// EFFECTS: shadow / glow / softEdge / reflection / fillOverlay / blur
 					// REF: @see http://officeopenxml.com/drwSp-effects.php
 					strSlideXml += genXmlEffectLst({
 						shadow: slideItemObj.options.shadow,
@@ -898,10 +1035,15 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 						softEdge: slideItemObj.options.softEdge,
 						reflection: slideItemObj.options.reflection,
 						blur: slideItemObj.options.blur,
+						fillOverlay: slideItemObj.options.fillOverlay,
+						effectDag: slideItemObj.options.effectDag,
 					})
 
 					// B: Close shape Properties
 					strSlideXml += '</p:spPr>'
+
+					// `p:style` follows `p:spPr` in CT_Shape / CT_Connector
+					strSlideXml += genXmlShapeStyle(slideItemObj.options.styleRef)
 
 					if (isConnector) {
 					// Connectors have no text body
@@ -940,7 +1082,7 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					(slide._relsMedia || []).filter(rel => rel.rId === slideItemObj.imageRid)[0].extn === 'svg'
 					) {
 						strSlideXml += `<a:blip r:embed="rId${(slideItemObj.imageRid ?? 0) - 1}">`
-						strSlideXml += slideItemObj.options.transparency ? ` <a:alphaModFix amt="${Math.round((100 - slideItemObj.options.transparency) * 1000)}"/>` : ''
+						strSlideXml += genXmlBlipEffects(slideItemObj.options.transparency, slideItemObj.options.alphaEffects, slideItemObj.options.recolor)
 						strSlideXml += ' <a:extLst>'
 						strSlideXml += '  <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">'
 						strSlideXml += `   <asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="rId${slideItemObj.imageRid}"/>`
@@ -949,7 +1091,7 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 						strSlideXml += '</a:blip>'
 					} else {
 						strSlideXml += `<a:blip r:embed="rId${slideItemObj.imageRid}">`
-						strSlideXml += slideItemObj.options.transparency ? `<a:alphaModFix amt="${Math.round((100 - slideItemObj.options.transparency) * 1000)}"/>` : ''
+						strSlideXml += genXmlBlipEffects(slideItemObj.options.transparency, slideItemObj.options.alphaEffects, slideItemObj.options.recolor)
 						strSlideXml += '</a:blip>'
 					}
 					if (sizing?.type) {
@@ -1004,15 +1146,18 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					// OUTLINE: picture border/frame (issue #35)
 					if (slideItemObj.options.line) strSlideXml += genXmlLine(slideItemObj.options.line)
 
-					// EFFECTS: shadow / glow / softEdge / reflection
+					// EFFECTS: shadow / glow / softEdge / reflection / fillOverlay / blur
 					strSlideXml += genXmlEffectLst({
 						shadow: slideItemObj.options.shadow,
 						glow: slideItemObj.options.glow,
 						softEdge: slideItemObj.options.softEdge,
 						reflection: slideItemObj.options.reflection,
 						blur: slideItemObj.options.blur,
+						fillOverlay: slideItemObj.options.fillOverlay,
+						effectDag: slideItemObj.options.effectDag,
 					})
 					strSlideXml += '</p:spPr>'
+					strSlideXml += genXmlShapeStyle(slideItemObj.options.styleRef)
 					strSlideXml += '</p:pic>'
 					break
 
@@ -1180,12 +1325,15 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					strSlideXml += `<a:off x="${x}" y="${y}"/><a:ext cx="${cx}" cy="${cy}"/>`
 					strSlideXml += `<a:chOff x="0" y="0"/><a:chExt cx="${cx}" cy="${cy}"/>`
 					strSlideXml += '</a:xfrm>'
+					if (slideItemObj.options.fill) strSlideXml += genXmlColorSelection(slideItemObj.options.fill)
 					strSlideXml += genXmlEffectLst({
 						shadow: slideItemObj.options.shadow,
 						glow: slideItemObj.options.glow,
 						softEdge: slideItemObj.options.softEdge,
 						reflection: slideItemObj.options.reflection,
 						blur: slideItemObj.options.blur,
+						fillOverlay: slideItemObj.options.fillOverlay,
+						effectDag: slideItemObj.options.effectDag,
 					})
 					strSlideXml += '</p:grpSpPr>'
 					renderObjectList(slideItemObj._objects ?? [])

--- a/src/xml/text.ts
+++ b/src/xml/text.ts
@@ -524,6 +524,8 @@ export function genXmlTextBody (slideObj: ISlideObject | TableCell): string {
 			delete runOpts.softEdge
 			delete runOpts.reflection
 			delete runOpts.shadow
+			delete runOpts.fillOverlay
+			delete runOpts.effectDag
 			itext.options = runOpts
 		}
 		if (idx === 0 && itext.options && !itext.options.bullet && opts.bullet) itext.options.bullet = opts.bullet
@@ -641,7 +643,7 @@ export function genXmlTextBody (slideObj: ISlideObject | TableCell): string {
 				// NOTE: This loop will pick up unecessary keys (`x`, etc.), but it doesnt hurt anything
 				// `glow` / softEdge / reflection belong on the shape effectLst (not per-run), unless set on the run itself
 				// `omml` is a run-level math payload — inheriting it would replace sibling plain-text runs
-				if (key === 'glow' || key === 'softEdge' || key === 'reflection' || key === 'shadow' || key === 'blur' || key === 'omml') return
+				if (key === 'glow' || key === 'softEdge' || key === 'reflection' || key === 'shadow' || key === 'blur' || key === 'fillOverlay' || key === 'effectDag' || key === 'omml') return
 				if (key !== 'bullet' && !textOpts[key]) textOpts[key] = val
 			})
 

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -260,3 +260,54 @@ test('contract: rejects a comments part without a slide relationship', async () 
 	)
 	await assert.rejects(assertModernCommentPartContracts(invalidZip), /MUST be the target of an explicit relationship/)
 })
+
+const FILL_PNG = 'image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII='
+
+test('contract: picture fills emit a:blipFill wired to an image relationship', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addShape(pptx.ShapeType.rect, { x: 1, y: 1, w: 2, h: 1, fill: { type: 'image', image: { data: FILL_PNG } } })
+	slide.addShape(pptx.ShapeType.rect, { x: 4, y: 1, w: 2, h: 1, fill: { type: 'image', image: { data: FILL_PNG, sizing: 'tile', scale: 50, alignment: 'ctr', rotateWithShape: false } } })
+	slide.addTable([[{ text: 'i', options: { fill: { type: 'image', image: { data: FILL_PNG } } } }]], { x: 1, y: 3, w: 4 })
+	const picZip = await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer)
+	await assertPptxPackageContracts(picZip)
+	const xml = await readPart(picZip, 'ppt/slides/slide1.xml')
+
+	assert.doesNotMatch(xml, /NaN|undefined/, 'picture-fill options must not leak invalid values')
+	assert.match(xml, /<a:blipFill rotWithShape="1"><a:blip r:embed="rId\d+"\/><a:stretch><a:fillRect\/><\/a:stretch><\/a:blipFill>/, 'stretch picture fill missing')
+	assert.match(xml, /<a:blipFill rotWithShape="0"><a:blip r:embed="rId\d+"\/><a:tile tx="0" ty="0" sx="50000" sy="50000" flip="none" algn="ctr"\/><\/a:blipFill>/, 'tiled picture fill missing')
+	assert.match(xml, /<a:tcPr[\s\S]*?<a:blipFill /, 'table cell picture fill missing')
+
+	const rels = await readPart(picZip, 'ppt/slides/_rels/slide1.xml.rels')
+	const embeds = [...xml.matchAll(/<a:blip r:embed="(rId\d+)"\/>/g)].map(match => match[1])
+	assert.equal(embeds.length, 3, 'expected one blip per picture fill')
+	embeds.forEach(rid => {
+		assert.match(rels, new RegExp(`<Relationship Id="${rid}" Type="[^"]*\\/image" Target="\\.\\./media/[^"]+"\\/>`), `${rid} has no image relationship`)
+	})
+	// identical bytes share one part (content-hash dedupe); each fill still has its own relationship
+	assert.ok(Object.keys(picZip.files).some(file => /^ppt\/media\/.+/.test(file)), 'image part missing')
+})
+
+test('contract: invalid picture fills degrade instead of writing broken XML', async () => {
+	const warnings: string[] = []
+	const origWarn = console.warn
+	console.warn = (msg: string) => warnings.push(String(msg))
+	let xml = ''
+	try {
+		const pptx = new pptxgen()
+		const slide = pptx.addSlide()
+		slide.addShape(pptx.ShapeType.rect, { x: 1, y: 3, w: 2, h: 1, fill: { type: 'image', image: {} } })
+		slide.addShape(pptx.ShapeType.rect, { x: 4, y: 3, w: 2, h: 1, fill: { type: 'image', image: { data: 'not-base64' } } })
+		slide.addShape(pptx.ShapeType.rect, { x: 1, y: 5, w: 2, h: 1, fill: { type: 'image', image: { data: FILL_PNG, sizing: 'tile', alignment: 'middle' as unknown as 'ctr' } } })
+		xml = await readPart(await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer), 'ppt/slides/slide1.xml')
+	} finally {
+		console.warn = origWarn
+	}
+
+	assert.ok(warnings.some(w => w.includes('requires `fill.image.data` or `fill.image.path`')), 'missing image must warn')
+	assert.ok(warnings.some(w => w.includes('lacks a base64 header')), 'bad image data must warn')
+	assert.ok(warnings.some(w => w.includes('unknown tile alignment "middle"')), 'bad alignment must warn')
+	assert.equal([...xml.matchAll(/<a:blip r:embed=/g)].length, 1, 'only the valid picture fill may emit a blip')
+	assert.match(xml, /algn="tl"/, 'an unknown tile alignment falls back to tl')
+	assert.doesNotMatch(xml, /r:embed="rId0"/, 'no fill may reference a non-existent relationship')
+})

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -3507,3 +3507,188 @@ test('OMML: malformed omml option throws instead of writing a corrupt package', 
 	const xml = await readPart(await writeZip(pptx3), 'ppt/slides/slide1.xml')
 	assert.ok(xml.includes('a&lt;b&amp;c'), 'valid OMML was rejected or mangled')
 })
+
+test('Neoma fills/fx: fillOverlay, prstShdw, effectDag, blip alpha effects and group fill', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addShape(pptx.ShapeType.rect, {
+		x: 0.5, y: 0.5, w: 2, h: 1, fill: { color: 'CCCCCC' },
+		blur: { radius: 4, grow: false },
+		fillOverlay: { blend: 'mult', fill: { color: 'FF0000', transparency: 50 } },
+		glow: { size: 5, color: '00FF00', opacity: 0.4 },
+		shadow: { type: 'outer', color: '000000' },
+		reflection: { blur: 2 },
+		softEdge: { radius: 3 },
+	})
+	slide.addShape(pptx.ShapeType.rect, { x: 3, y: 0.5, w: 2, h: 1, shadow: { type: 'preset', preset: 'shdw7', color: '333333' } })
+	slide.addShape(pptx.ShapeType.rect, { x: 5.5, y: 0.5, w: 2, h: 1, glow: { size: 4, color: 'FF0000', opacity: 0.5 }, effectDag: { type: 'tree' } })
+	slide.addShape(pptx.ShapeType.rect, { x: 0.5, y: 2, w: 2, h: 1, fill: { type: 'group' } })
+	slide.addShape(pptx.ShapeType.rect, { x: 3, y: 2, w: 2, h: 1, shadow: { type: 'preset', color: '333333' } })
+	slide.addShape(pptx.ShapeType.rect, { x: 5.5, y: 2, w: 2, h: 1, fillOverlay: { blend: 'over' } as never })
+	slide.addShape(pptx.ShapeType.rect, { x: 8, y: 2, w: 1, h: 1, fillOverlay: { fill: { color: '00FF00' } } as never })
+	slide.addImage({ data: PNG_4x2, x: 0.5, y: 3.5, w: 1, h: 0.5, transparency: 20, alphaEffects: { replace: 60, invert: true, floor: true, ceiling: true } })
+	slide.addImage({ data: PNG_4x2, x: 2, y: 3.5, w: 1, h: 0.5, alphaEffects: { replace: 150 } })
+
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide1.xml')
+	const lists = xml.match(/<a:effectLst>[\s\S]*?<\/a:effectLst>/g) ?? []
+	assert.ok(lists.length >= 2, `expected effect lists, got ${lists.length}`)
+
+	const all = lists[0]
+	assert.ok(all.includes('<a:blur rad="50800" grow="0"/>'), `blur wrong: ${all}`)
+	assert.ok(all.includes('<a:fillOverlay blend="mult"><a:solidFill><a:srgbClr val="FF0000"><a:alpha val="50000"/></a:srgbClr></a:solidFill></a:fillOverlay>'), `fillOverlay wrong: ${all}`)
+	const seq = ['<a:blur', '<a:fillOverlay', '<a:glow', '<a:outerShdw', '<a:reflection', '<a:softEdge'].map(tag => all.indexOf(tag))
+	assert.ok(seq.every(idx => idx > -1), `an effect is missing: ${seq.join(',')}`)
+	assert.deepEqual(seq, [...seq].sort((a, b) => a - b), `CT_EffectList child order violated: ${seq.join(',')}`)
+
+	assert.ok(xml.includes('<a:prstShdw prst="shdw7" dist="50800" dir="16200000"><a:srgbClr val="333333"><a:alpha val="75000"/></a:srgbClr></a:prstShdw>'), 'prstShdw missing')
+	assert.equal((xml.match(/<a:prstShdw/g) ?? []).length, 1, 'a preset shadow without a preset name was emitted')
+	assert.equal((xml.match(/<a:fillOverlay/g) ?? []).length, 1, 'a fill overlay missing its blend mode or its fill was emitted')
+	assert.ok(!xml.includes('blend="undefined"'), 'a fill overlay was emitted without a blend mode')
+
+	const dag = /<a:effectDag[\s\S]*?<\/a:effectDag>/.exec(xml)?.[0] ?? ''
+	assert.ok(dag.startsWith('<a:effectDag type="tree">') && dag.includes('<a:glow'), `effectDag wrong: ${dag}`)
+	const dagShape = /<p:sp>(?:(?!<\/p:sp>)[\s\S])*<a:effectDag[\s\S]*?<\/p:sp>/.exec(xml)?.[0] ?? ''
+	assert.ok(dagShape && !dagShape.includes('<a:effectLst>'), 'a shape emitted both an effectDag and an effectLst')
+
+	assert.ok(xml.includes('<a:grpFill/>'), 'group fill missing')
+
+	const blips = xml.match(/<a:blip [\s\S]*?<\/a:blip>/g) ?? []
+	assert.ok(blips[0].includes('<a:alphaModFix amt="80000"/><a:alphaRepl a="60000"/><a:alphaInv/><a:alphaFloor/><a:alphaCeiling/>'), `blip alpha effects wrong: ${blips[0]}`)
+	assert.ok(blips[1].includes('<a:alphaRepl a="100000"/>'), `alphaRepl not clamped: ${blips[1]}`)
+	for (const list of lists) assert.ok(!/alphaRepl|alphaInv|alphaFloor|alphaCeiling/.test(list), 'an alpha effect leaked into a:effectLst')
+
+	const imgOnly = new pptxgen()
+	imgOnly.addSlide().addImage({ data: PNG_4x2, x: 1, y: 1, w: 1, h: 0.5, glow: { size: 5, color: 'FF0000', opacity: 0.5 }, softEdge: { radius: 3 }, reflection: { blur: 2 } })
+	const picXml = await readPart(await writeZip(imgOnly), 'ppt/slides/slide1.xml')
+	const pic = /<p:pic>[\s\S]*?<\/p:pic>/.exec(picXml)?.[0] ?? ''
+	assert.ok(pic.includes('<a:glow') && pic.includes('<a:softEdge') && pic.includes('<a:reflection'), `image effects never reached the pic: ${pic}`)
+
+	const bare = new pptxgen()
+	bare.addSlide().addShape(pptx.ShapeType.rect, { x: 1, y: 1, w: 2, h: 1, fill: { color: 'CCCCCC' } })
+	const bareXml = await readPart(await writeZip(bare), 'ppt/slides/slide1.xml')
+	for (const tag of ['<a:blur', '<a:fillOverlay', '<a:prstShdw', '<a:effectDag', '<a:grpFill', '<a:alphaRepl']) {
+		assert.ok(!bareXml.includes(tag), `default shape gained ${tag}`)
+	}
+})
+
+test('Neoma fills/fx: picture recolor and correction effects', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addImage({ data: PNG_4x2, x: 0.5, y: 0.5, w: 1, h: 0.5, recolor: { duotone: ['000000', 'accent1'], brightness: 20, contrast: -10 } })
+	slide.addImage({ data: PNG_4x2, x: 2, y: 0.5, w: 1, h: 0.5, recolor: { grayscale: true, blackWhiteThreshold: 50 } })
+	slide.addImage({ data: PNG_4x2, x: 3.5, y: 0.5, w: 1, h: 0.5, recolor: { colorChange: { from: 'FFFFFF', to: '00FF00', useAlpha: false } } })
+	slide.addImage({ data: PNG_4x2, x: 5, y: 0.5, w: 1, h: 0.5, transparency: 30, recolor: { brightness: 150 } })
+	slide.addImage({ data: PNG_4x2, x: 6.5, y: 0.5, w: 1, h: 0.5, recolor: { duotone: ['000000'] as never, colorChange: { from: 'FFFFFF' } as never } })
+
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide1.xml')
+	const blips = xml.match(/<a:blip [\s\S]*?<\/a:blip>/g) ?? []
+	assert.equal(blips.length, 5, `expected five blips, got ${blips.length}`)
+
+	assert.ok(blips[0].includes('<a:duotone><a:srgbClr val="000000"/><a:schemeClr val="accent1"/></a:duotone>'), `duotone wrong: ${blips[0]}`)
+	assert.ok(blips[0].includes('<a:lum bright="20000" contrast="-10000"/>'), `lum wrong: ${blips[0]}`)
+	assert.ok(blips[1].includes('<a:grayscl/>'), 'grayscl missing')
+	assert.ok(blips[1].includes('<a:biLevel thresh="50000"/>'), `biLevel wrong: ${blips[1]}`)
+	assert.ok(blips[2].includes('<a:clrChange useA="0"><a:clrFrom><a:srgbClr val="FFFFFF"/></a:clrFrom><a:clrTo><a:srgbClr val="00FF00"/></a:clrTo></a:clrChange>'), `clrChange wrong: ${blips[2]}`)
+	assert.ok(blips[3].includes('<a:alphaModFix amt="70000"/>') && blips[3].includes('<a:lum bright="100000"/>'), `clamping or coexistence wrong: ${blips[3]}`)
+	assert.ok(!blips[4].includes('duotone') && !blips[4].includes('clrChange'), `an incomplete effect was emitted: ${blips[4]}`)
+
+	const bg = new pptxgen()
+	const bgSlide = bg.addSlide()
+	bgSlide.background = { data: PNG_4x2, recolor: { grayscale: true, brightness: -20 } }
+	bgSlide.addText('bg', { x: 1, y: 1 })
+	const plain = bg.addSlide()
+	plain.background = { data: PNG_4x2 }
+	plain.addText('plain', { x: 1, y: 1 })
+	assert.ok((await readPart(await writeZip(bg), 'ppt/slides/slide1.xml')).includes('<a:grayscl/><a:lum bright="-20000"/></a:blip>'), 'background recolour missing')
+	assert.ok((await readPart(await writeZip(bg), 'ppt/slides/slide2.xml')).includes('<a:blip r:embed="rId1"><a:lum/></a:blip>'), 'the default background blip changed')
+
+	const bare = new pptxgen()
+	bare.addSlide().addImage({ data: PNG_4x2, x: 1, y: 1, w: 1, h: 0.5 })
+	const bareXml = await readPart(await writeZip(bare), 'ppt/slides/slide1.xml')
+	for (const tag of ['<a:duotone', '<a:grayscl', '<a:lum', '<a:biLevel', '<a:clrChange']) {
+		assert.ok(!bareXml.includes(tag), `a default image gained ${tag}`)
+	}
+})
+
+test('Neoma fills/fx: shapes and pictures emit p:style theme references', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addShape(pptx.ShapeType.rect, { x: 0.5, y: 0.5, w: 2, h: 1, styleRef: { line: 1, fill: 3, effect: 2, font: 'minor' } })
+	slide.addShape(pptx.ShapeType.rect, { x: 3, y: 0.5, w: 2, h: 1, styleRef: { fill: 1 }, fill: { color: 'FF0000' } })
+	slide.addShape(pptx.ShapeType.rect, { x: 5.5, y: 0.5, w: 2, h: 1, styleRef: { effect: 1, color: 'phClr' } })
+	slide.addImage({ data: PNG_4x2, x: 0.5, y: 2, w: 1, h: 0.5, styleRef: { line: 2, color: 'accent3' } })
+
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide1.xml')
+	const shapes = xml.match(/<p:sp>[\s\S]*?<\/p:sp>/g) ?? []
+	assert.equal(shapes.length, 3, `expected three shapes, got ${shapes.length}`)
+
+	assert.ok(shapes[0].includes(
+		'<p:style><a:lnRef idx="1"><a:schemeClr val="accent1"/></a:lnRef>' +
+		'<a:fillRef idx="3"><a:schemeClr val="accent1"/></a:fillRef>' +
+		'<a:effectRef idx="2"><a:schemeClr val="accent1"/></a:effectRef>' +
+		'<a:fontRef idx="minor"><a:schemeClr val="lt1"/></a:fontRef></p:style>'
+	), `p:style wrong: ${shapes[0]}`)
+
+	const order = ['</p:spPr>', '<p:style>', '</p:style>', '<p:txBody>'].map(tag => shapes[0].indexOf(tag))
+	assert.ok(order.every(idx => idx > -1), `a p:sp child is missing: ${order.join(',')}`)
+	assert.deepEqual(order, [...order].sort((a, b) => a - b), `CT_Shape child order violated: ${order.join(',')}`)
+
+	const spPr0 = /<p:spPr>[\s\S]*?<\/p:spPr>/.exec(shapes[0])?.[0] ?? ''
+	assert.ok(!spPr0.includes('<a:noFill/>') && !spPr0.includes('<a:solidFill>'), `a referenced fill must be left to the theme: ${spPr0}`)
+
+	const spPr1 = /<p:spPr>[\s\S]*?<\/p:spPr>/.exec(shapes[1])?.[0] ?? ''
+	assert.ok(spPr1.includes('<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>'), 'an explicit fill was dropped')
+	assert.ok(shapes[1].includes('<a:lnRef idx="0">') && shapes[1].includes('<a:effectRef idx="0">') && shapes[1].includes('<a:fontRef idx="none">'), `unset refs wrong: ${shapes[1]}`)
+
+	assert.ok(shapes[2].includes('<a:effectRef idx="1"><a:schemeClr val="accent1"/></a:effectRef>'), 'phClr was not rejected')
+	assert.ok(!xml.includes('val="phClr"'), 'phClr reached the output')
+	assert.ok((/<p:spPr>[\s\S]*?<\/p:spPr>/.exec(shapes[2])?.[0] ?? '').includes('<a:noFill/>'), 'the noFill default was suppressed without a fill reference')
+
+	const pic = /<p:pic>[\s\S]*?<\/p:pic>/.exec(xml)?.[0] ?? ''
+	assert.ok(pic.includes('<a:lnRef idx="2"><a:schemeClr val="accent3"/></a:lnRef>'), `picture p:style wrong: ${pic}`)
+	const picOrder = ['</p:spPr>', '<p:style>', '</p:pic>'].map(tag => pic.indexOf(tag))
+	assert.deepEqual(picOrder, [...picOrder].sort((a, b) => a - b), `CT_Picture child order violated: ${picOrder.join(',')}`)
+
+	const bare = new pptxgen()
+	bare.addSlide().addShape(pptx.ShapeType.rect, { x: 1, y: 1, w: 2, h: 1 })
+	const bareXml = await readPart(await writeZip(bare), 'ppt/slides/slide1.xml')
+	assert.ok(!bareXml.includes('<p:style>'), 'default shape gained a p:style')
+	assert.ok(bareXml.includes('<a:noFill/>'), 'default shape lost its noFill')
+})
+
+test('Neoma fills/fx: addConnector maps onto existing connector fields via objectName', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addShape(pptx.ShapeType.rect, {
+		objectName: 'BoxA',
+		x: 0.5, y: 1, w: 2, h: 1,
+		fill: { color: '4472C4' },
+	})
+	slide.addShape(pptx.ShapeType.rect, {
+		objectName: 'BoxB',
+		x: 5, y: 2, w: 2, h: 1,
+		fill: { color: 'ED7D31' },
+	})
+	slide.addConnector({
+		type: 'straightConnector1',
+		start: { shape: 'BoxA', site: pptx.anchor.RIGHT },
+		end: { shape: 'BoxB', site: pptx.anchor.LEFT },
+		line: { width: 2, color: '000000' },
+	})
+
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide1.xml')
+	assert.ok(xml.includes('<p:cxnSp>'), 'missing p:cxnSp connector')
+	assert.ok(xml.includes('prst="straightConnector1"'), 'connector preset missing')
+	assert.ok(/<a:stCxn id="\d+" idx="3"\/>/.test(xml), 'stCxn objectName glue missing')
+	assert.ok(/<a:endCxn id="\d+" idx="1"\/>/.test(xml), 'endCxn objectName glue missing')
+	assert.ok(/<a:ext cx="[1-9]\d*"/.test(xml), 'connector auto-layout should produce non-zero width')
+
+	const unknown = new pptxgen()
+	const uSlide = unknown.addSlide()
+	uSlide.addShape(pptx.ShapeType.rect, { objectName: 'Only', x: 1, y: 1, w: 1, h: 1 })
+	uSlide.addConnector({ start: { shape: 'Missing' }, end: { shape: 'AlsoMissing' } })
+	const uXml = await readPart(await writeZip(unknown), 'ppt/slides/slide1.xml')
+	assert.ok(uXml.includes('<p:cxnSp>'), 'unknown objectName should still emit a connector')
+	assert.ok(!uXml.includes('<a:stCxn'), 'unknown start attachment must be dropped')
+	assert.ok(!uXml.includes('<a:endCxn'), 'unknown end attachment must be dropped')
+})


### PR DESCRIPTION
## Summary
- Additive port of Neoma picture fills (`fill.type: "image"` / `a:blipFill` stretch+tile), remaining DrawingML effects (`fillOverlay`, `prstShdw`, `effectDag`, `alphaEffects`, `grpFill`), image `recolor` on `a:blip`, and `styleRef` (`p:style`).
- Kept existing pattern/gradient APIs, SVG `fill` path recolor, `addGroup(options, builder)` signature, and ZentoSoft connector auto-layout (`line.isConnector` + sourceId/targetId).
- Added `slide.addConnector()` as a convenience that maps onto those connector fields, with optional `start`/`end` `objectName` glue. Skipped Neoma `addGroup(children[])` and artistic effects (no raster pipeline / MS-ODRAWXML).

## Test plan
- [x] `bun test test/contracts.test.ts test/issues.test.ts`
- [ ] Confirm a shape picture fill (stretch + tile) opens in PowerPoint without repair
- [ ] Confirm `styleRef` restyles when swapping the theme
- [ ] Confirm `addConnector({ start, end })` stays glued after moving the named shapes
