### PR TITLE
feat: port Neoma presentation, layout, locks, and unit lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `slide.creationId = true` assigns a reproducible `p14:creationId`; tables get unique default `p14:modId` values
 - `addSummaryZoom({ sectionTitles })` can target multiple sections
 - `pptxgenjs-plus-std` workspace package with `grid` / `gridFor` layout helpers and a stacked-bar `waterfall` construction (ported from NeomaVerwaltung/PptxGenJS)
+- Opt-in presentation children: `photoAlbum`, `kinsoku`, `slideSizeType` (`p:sldSz@type`); print/recent-color props land on `presentationPr` (`printProps`, `recentColors`)
+- Configurable `viewProps` (zoom, snap, guides, lastView) — the hardcoded `viewProps.xml` is kept until the caller sets options
+- Extra `documentProps` for core.xml/app.xml (keywords, category, description, manager, template, counts)
+- Slide-layout metadata (`layoutType`, `matchingName`, `showMasterShapes`, `preserve`, colour-map override, per-layout transition) and placeholder `orient`/`sz`/`userDrawn`
+- Editing locks (`lock`) plus `cNvPr` `title`/`hidden` on shapes, groups, images, tables, and connectors
+- `UnitLength` (`in`/`cm`/`mm`/`pt`) on `Coord`; unit-suffixed strings parse in `getSmartParseNumber` / `inch2Emu`
 
 ### Changed
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/pptxgenjs-jsx": {
       "name": "pptxgenjs-plus-jsx",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "dependencies": {
         "pptxgenjs-plus": "file:../..",
       },
@@ -35,14 +35,14 @@
     },
     "packages/pptxgenjs-std": {
       "name": "pptxgenjs-plus-std",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "devDependencies": {
         "@types/node": "^26.2.0",
         "pptxgenjs-plus": "file:../..",
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "pptxgenjs-plus": "4.1.19",
+        "pptxgenjs-plus": "4.1.20",
       },
     },
   },

--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -10,6 +10,16 @@ export const EMU = 914400 // One (1) inch (OfficeXML measures in EMU (English Me
 export const ONEPT = 12700 // One (1) point (pt)
 export const CRLF = '\r\n' // AKA: Chr(13) & Chr(10)
 export const LAYOUT_IDX_SERIES_BASE = 2147483649
+/**
+ * ECMA-376 20.1.6.2 CT_ColorMapping - the identity map, which is what `a:masterClrMapping` means
+ * - all twelve attributes are required, so a partial `colorMapOverride` is filled from this
+ */
+export const DEF_COLOR_MAP = Object.freeze({
+	bg1: 'lt1', tx1: 'dk1', bg2: 'lt2', tx2: 'dk2',
+	accent1: 'accent1', accent2: 'accent2', accent3: 'accent3',
+	accent4: 'accent4', accent5: 'accent5', accent6: 'accent6',
+	hlink: 'hlink', folHlink: 'folHlink',
+})
 export const REGEX_HEX_COLOR = /^[0-9a-fA-F]{6}$/
 export const LINEH_MODIFIER = 1.67 // AKA: Golden Ratio Typography
 

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -12,11 +12,14 @@ import { CHART_NAME, PLACEHOLDER_TYPE, SHAPE_NAME, SLIDE_OBJECT_TYPES, TEXT_HALI
  * Coordinate number - either:
  * - Inches (0-n)
  * - Percentage (0-100)
+ * - Unit-suffixed length (`in` / `cm` / `mm` / `pt`)
  *
  * @example 10.25 // coordinate in inches
+ * @example '2.5cm' // coordinate with an explicit unit
  * @example '75%' // coordinate as percentage of slide size
  */
-export type Coord = number | `${number}%`
+export type UnitLength = `${number}in` | `${number}cm` | `${number}mm` | `${number}pt`
+export type Coord = number | `${number}%` | UnitLength
 export interface PositionProps {
 	/**
 	 * Horizontal position
@@ -1019,8 +1022,76 @@ export interface PlaceholderProps extends PositionProps, TextBaseProps, NvPrExte
 	 * Placeholder background fill. Kept when a slide inherits layout defaults (caller fill wins).
 	 */
 	fill?: ShapeFillProps
+	/**
+	 * Text direction inside the placeholder (`p:ph@orient`)
+	 * @default horz
+	 */
+	orient?: 'horz' | 'vert'
+	/**
+	 * How much of the layout the placeholder covers (`p:ph@sz`)
+	 * @default full
+	 */
+	sz?: 'full' | 'half' | 'quarter'
+	/**
+	 * Mark the placeholder as drawn by the author rather than inherited layout furniture
+	 * (`p:nvPr@userDrawn`)
+	 * @default false
+	 */
+	userDrawn?: boolean
 }
-export interface ObjectNameProps {
+/**
+ * Editing locks (ECMA-376 20.1.2.2.34 `a:spLocks` and its siblings)
+ * - each is omitted unless set, so the values the library emits today are unchanged
+ */
+export interface ShapeLockProps {
+	/** prevent grouping with other shapes */
+	noGroup?: boolean
+	/** prevent selection */
+	noSelect?: boolean
+	/** prevent rotation */
+	noRotate?: boolean
+	/** prevent changing the aspect ratio */
+	noChangeAspect?: boolean
+	/** prevent moving */
+	noMove?: boolean
+	/** prevent resizing */
+	noResize?: boolean
+	/** prevent editing the geometry points */
+	noEditPoints?: boolean
+	/** prevent dragging the adjust handles */
+	noAdjustHandles?: boolean
+	/** prevent changing arrowheads */
+	noChangeArrowheads?: boolean
+	/** prevent changing the preset geometry */
+	noChangeShapeType?: boolean
+	/** prevent editing the text */
+	noTextEdit?: boolean
+	/** pictures only: prevent cropping */
+	noCrop?: boolean
+	/** pictures only: prefer resizing relative to the original size */
+	preferRelativeResize?: boolean
+}
+/**
+ * Non-visual drawing properties beyond the name (ECMA-376 19.3.1.12 `p:cNvPr`)
+ */
+export interface NonVisualProps {
+	/**
+	 * Alt-text *title*, distinct from the description
+	 * - PowerPoint: right-click > Edit Alt Text
+	 */
+	title?: string
+	/**
+	 * Hide the shape
+	 * - it stays in the file and can be re-shown from the selection pane
+	 * @default false
+	 */
+	hidden?: boolean
+	/**
+	 * Editing locks for this shape
+	 */
+	lock?: ShapeLockProps
+}
+export interface ObjectNameProps extends NonVisualProps {
 	/**
 	 * Object name
 	 * - used instead of default "Object N" name
@@ -2828,11 +2899,83 @@ export interface SlideNumberProps extends PositionProps, TextBaseProps {
 	 */
 	margin?: Margin // TODO: convert to inches in 4.0 (valid values are 0-22)
 }
+/**
+ * ECMA-376 20.1.10.14 ST_ColorSchemeIndex - a slot in the theme's colour scheme
+ */
+export type ColorSchemeIndex = 'dk1' | 'lt1' | 'dk2' | 'lt2' | 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6' | 'hlink' | 'folHlink'
+
+/**
+ * Per-layout colour map override (`p:clrMapOvr` > `a:overrideClrMapping`)
+ * - remaps the presentation's colour slots for one layout
+ * - all twelve attributes are required by the schema, so anything left unset is filled from the
+ *   identity map (which is what inheriting the master's mapping means)
+ */
+export interface ColorMapOverrideProps {
+	bg1?: ColorSchemeIndex
+	tx1?: ColorSchemeIndex
+	bg2?: ColorSchemeIndex
+	tx2?: ColorSchemeIndex
+	accent1?: ColorSchemeIndex
+	accent2?: ColorSchemeIndex
+	accent3?: ColorSchemeIndex
+	accent4?: ColorSchemeIndex
+	accent5?: ColorSchemeIndex
+	accent6?: ColorSchemeIndex
+	hlink?: ColorSchemeIndex
+	folHlink?: ColorSchemeIndex
+}
+
+/**
+ * ECMA-376 19.7.15 ST_SlideLayoutType - the placeholder arrangement a layout describes
+ * - PowerPoint's layout gallery and its Reset Layout command read this
+ */
+export type SlideLayoutType = 'title' | 'tx' | 'twoColTx' | 'tbl' | 'txAndChart' | 'chartAndTx' | 'dgm' | 'chart' | 'txAndClipArt' | 'clipArtAndTx' | 'titleOnly' | 'blank' | 'txAndObj' | 'objAndTx' | 'objOnly' | 'obj' | 'txAndMedia' | 'mediaAndTx' | 'objOverTx' | 'txOverObj' | 'txAndTwoObj' | 'twoObjAndTx' | 'twoObjOverTx' | 'fourObj' | 'vertTx' | 'clipArtAndVertTx' | 'vertTitleAndTx' | 'vertTitleAndTxOverChart' | 'twoObj' | 'objAndTwoObj' | 'twoObjAndObj' | 'cust' | 'secHead' | 'twoTxTwoObj' | 'objTx' | 'picTx'
+
 export interface SlideMasterProps {
 	/**
 	 * Unique name for this master
 	 */
 	title: string
+	/**
+	 * Which placeholder arrangement this layout describes (`p:sldLayout@type`)
+	 * - PowerPoint's New Slide gallery groups layouts by this, and Reset Layout trusts it
+	 * @default cust
+	 */
+	layoutType?: SlideLayoutType
+	/**
+	 * Name shown for the layout in PowerPoint's gallery (`@matchingName`)
+	 * - unset writes nothing; PowerPoint then falls back to the layout name from `title`
+	 */
+	matchingName?: string
+	/**
+	 * Keep the layout in the deck even when no slide uses it (`@preserve`)
+	 * @default true
+	 */
+	preserve?: boolean
+	/**
+	 * Draw the master's shapes behind slides using this layout (`@showMasterSp`)
+	 * @default true
+	 */
+	showMasterShapes?: boolean
+	/**
+	 * Play the master's placeholder animations on slides using this layout (`@showMasterPhAnim`)
+	 * @default true
+	 */
+	showMasterPlaceholderAnimation?: boolean
+	/**
+	 * Mark the layout as drawn by the author rather than generated (`@userDrawn`)
+	 * @default false
+	 */
+	userDrawn?: boolean
+	/**
+	 * Remap the theme's colour slots for this layout only (`p:clrMapOvr`)
+	 * - with none set the layout inherits the master's mapping, which is today's behaviour
+	 */
+	colorMapOverride?: ColorMapOverrideProps
+	/**
+	 * Transition applied to slides using this layout (`p:transition`)
+	 */
+	transition?: SlideTransitionProps
 	background?: BackgroundProps
 	margin?: Margin
 	slideNumber?: SlideNumberProps
@@ -2866,6 +3009,12 @@ export interface SlideMasterProps {
 export interface ObjectOptions extends ImageProps, PositionProps, ShapeProps, TableCellProps, TextPropsOptions {
 	_placeholderIdx?: number
 	_placeholderType?: PLACEHOLDER_TYPE
+	/** placeholder text direction (`p:ph@orient`) */
+	orient?: 'horz' | 'vert'
+	/** placeholder size (`p:ph@sz`) */
+	sz?: 'full' | 'half' | 'quarter'
+	/** author-placed rather than layout furniture (`p:nvPr@userDrawn`) */
+	userDrawn?: boolean
 	/** image added without `w`/`h`: size it from the image itself during export @internal */
 	_sizeFromImage?: boolean
 	/** Caller set this axis; placeholder geometry must not overwrite it. */
@@ -2926,6 +3075,14 @@ export interface SlideBaseProps {
 	bkgd?: string | BackgroundProps
 }
 export interface SlideLayout extends SlideBaseProps {
+	layoutType?: SlideLayoutType
+	matchingName?: string
+	preserve?: boolean
+	showMasterShapes?: boolean
+	showMasterPlaceholderAnimation?: boolean
+	userDrawn?: boolean
+	colorMapOverride?: ColorMapOverrideProps
+	transition?: SlideTransitionProps
 	_slide?: {
 		_bkgdImgRid?: number
 		back: string
@@ -3250,6 +3407,104 @@ export interface SlideShowProps {
 	laserColor?: Color
 }
 
+/**
+ * Additional document properties (ECMA-376 15.2 and the OPC core properties)
+ * - each is omitted when unset, so `docProps` output is unchanged by default
+ */
+export interface DocumentProps {
+	/** `dc:description` - the Comments field in PowerPoint's Info pane */
+	description?: string
+	/** `dc:language`, ex: 'en-US' */
+	language?: string
+	/** `dc:identifier` */
+	identifier?: string
+	/** `cp:keywords`, comma-separated */
+	keywords?: string
+	/** `cp:category` */
+	category?: string
+	/** `cp:contentStatus`, ex: 'Draft' */
+	contentStatus?: string
+	/** `cp:version` */
+	version?: string
+	/** `cp:lastPrinted`, ISO 8601 */
+	lastPrinted?: string
+	/** `Manager` in app.xml */
+	manager?: string
+	/** `Template` in app.xml */
+	template?: string
+	/** `HyperlinkBase` in app.xml - the base for relative hyperlinks */
+	hyperlinkBase?: string
+	/** `TotalTime` in app.xml - editing time in minutes */
+	totalEditTime?: number
+}
+/**
+ * Slide-size preset (`p:sldSz@type`)
+ */
+export type SlideSizeType =
+	| 'screen4x3' | 'screen16x9' | 'screen16x10' | 'letter' | 'ledger' | 'a3' | 'a4' | 'b4ISO'
+	| 'b5ISO' | 'b4JIS' | 'b5JIS' | 'hagakiCard' | '35mm' | 'overhead' | 'banner' | 'custom'
+/**
+ * Photo-album mode (`p:photoAlbum`)
+ */
+export interface PhotoAlbumProps {
+	/** render in black and white */
+	blackWhite?: boolean
+	/** show captions below each picture */
+	showCaptions?: boolean
+	/** pictures per slide and orientation */
+	layout?: 'fitToSlide' | '1pic' | '2pic' | '4pic' | '1picTitle' | '2picTitle' | '4picTitle'
+	/** frame style drawn around each picture */
+	frame?: 'frameStyle1' | 'frameStyle2' | 'frameStyle3' | 'frameStyle4' | 'frameStyle5' | 'frameStyle6' | 'frameStyle7'
+}
+/**
+ * East Asian line-breaking rules (`p:kinsoku`)
+ */
+export interface KinsokuProps {
+	/** language the rules apply to, ex: 'ja-JP' */
+	lang?: string
+	/** characters that may not start a line */
+	invalidStartChars?: string
+	/** characters that may not end a line */
+	invalidEndChars?: string
+}
+/**
+ * Print defaults stored with the deck (`p:prnPr` on `presentationPr`)
+ */
+export interface PrintProps {
+	/** what to print */
+	what?: 'slides' | 'handouts1' | 'handouts2' | 'handouts3' | 'handouts4' | 'handouts6' | 'handouts9' | 'notes' | 'outline'
+	/** colour mode */
+	colorMode?: 'bw' | 'gray' | 'clr'
+	/** include hidden slides */
+	hiddenSlides?: boolean
+	/** scale to fit the paper */
+	scaleToFitPaper?: boolean
+	/** draw a frame around each slide */
+	frameSlides?: boolean
+}
+/**
+ * View properties stored in `ppt/viewProps.xml` (`p:viewPr`)
+ * - unset values keep the literal prior versions wrote
+ */
+export interface ViewProps {
+	/** zoom percent in the normal slide view @default 136 */
+	zoom?: number
+	/** snap objects to the grid @default false */
+	snapToGrid?: boolean
+	/** snap objects to each other @default true */
+	snapToObjects?: boolean
+	/** show drawing guides */
+	showGuides?: boolean
+	/** show comments and ink markup */
+	showComments?: boolean
+	/** grid spacing in inches @default 0.0833 (76200 EMU) */
+	gridSpacing?: number
+	/** view PowerPoint opens the deck in */
+	lastView?: 'sldView' | 'sldMasterView' | 'notesView' | 'handoutView' | 'notesMasterView' | 'outlineView' | 'sldSorterView' | 'sldThumbnailView'
+	/** classic drawing guides (`p:guideLst`), positioned in inches */
+	guides?: GuideProps[]
+}
+
 export interface PresentationProps {
 	author: string
 	company: string
@@ -3367,6 +3622,35 @@ export interface PresentationProps {
 	subject: string
 	theme?: ThemeProps
 	title: string
+	/**
+	 * Additional document properties written to `docProps`
+	 */
+	documentProps?: DocumentProps
+	/**
+	 * Slide-size preset (`p:sldSz@type`)
+	 * - the dimensions come from the layout; this records which preset they match
+	 */
+	slideSizeType?: SlideSizeType
+	/**
+	 * Photo-album mode (`p:photoAlbum`)
+	 */
+	photoAlbum?: PhotoAlbumProps
+	/**
+	 * East Asian line-breaking rules (`p:kinsoku`)
+	 */
+	kinsoku?: KinsokuProps
+	/**
+	 * Print defaults stored with the deck (`p:prnPr` on `presentationPr`)
+	 */
+	printProps?: PrintProps
+	/**
+	 * Recently-used colours shown in the colour picker (`p:clrMru` on `presentationPr`)
+	 */
+	recentColors?: Color[]
+	/**
+	 * View properties (`ppt/viewProps.xml`). Unset keeps the previous hardcoded viewPr.
+	 */
+	viewProps?: ViewProps
 }
 /** One collaborating application instance in `revInfo` (MS-PPTX §2.7.3.1 `CT_ClientRevision`). */
 export interface RevisionClientProps {

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -599,6 +599,10 @@ export function addImageDefinition(target: PresSlide | SlideLayout, opt: ImagePr
 		reflection: opt.reflection,
 		blur: opt.blur,
 		line: opt.line || imageBorderToLine(opt.border),
+		// non-visual props and locks are part of the object's identity, not its geometry
+		title: opt.title,
+		hidden: opt.hidden,
+		lock: opt.lock,
 		_sizeFromImage: !intWidth && !intHeight,
 		// addImage always writes x/y/w/h defaults, so remember which axes the caller actually set
 		// (placeholder geometry must not overwrite explicit placement; fujita-h d7e3e93 / #996).
@@ -1741,6 +1745,9 @@ export function addGroupDefinition (target: PresSlide, opts: GroupProps, objects
 			rotate: opts.rotate ?? 0,
 			shadow: opts.shadow ? correctShadowOptions(opts.shadow) : undefined,
 			objectName: opts.objectName ? encodeXmlEntities(opts.objectName) : `Group ${groupCount + 1}`,
+			title: opts.title,
+			hidden: opts.hidden,
+			lock: opts.lock,
 		},
 		_objects: objects,
 	}

--- a/src/gen-transition.ts
+++ b/src/gen-transition.ts
@@ -8,7 +8,7 @@
  * tools use the Fallback, so the file stays valid everywhere.
  */
 import type { TRANSITION_TYPE } from './core-enums'
-import type { PresSlide, SlideTransitionProps } from './core-interfaces'
+import type { SlideTransitionProps } from './core-interfaces'
 
 const P14_NS = 'http://schemas.microsoft.com/office/powerpoint/2010/main'
 const P15_NS = 'http://schemas.microsoft.com/office/powerpoint/2012/main'
@@ -136,7 +136,7 @@ function dirAttr(valid: string[], p: SlideTransitionProps): string {
  * Generates `<p:transition>...</p:transition>` for a slide, or '' if no transition is set.
  * Placed after `<p:clrMapOvr>` and before `<p:timing>` in the `sld` content model (ECMA-376 §19.3.1.38).
  */
-export function genXmlTransition(slide: PresSlide): string {
+export function genXmlTransition(slide: { transition?: SlideTransitionProps }): string {
 	const t = slide.transition
 	if (!t || !t.type) return ''
 

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -184,13 +184,38 @@ export function resolveDataLabelPosition (position: string, chartType?: string, 
 	return code
 }
 
+/** Units per inch, for the length suffixes accepted on `x`/`y`/`w`/`h` and the other inch-valued options */
+const UNITS_PER_INCH: Record<string, number> = { in: 1, cm: 2.54, mm: 25.4, pt: 72 }
+
+/**
+ * A number with a length suffix - `'2.5cm'`, `'-4mm'`, `'18pt'`, `'5in'`
+ * - the mantissa alternates rather than using `\d*\.?\d+`: that form lets the two digit runs
+ *   split a plain integer many ways, so a long non-matching digit string backtracks quadratically
+ */
+const REGEX_UNIT_LENGTH = /^\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*(in|cm|mm|pt)\s*$/i
+
+/**
+ * Parse a unit-suffixed length into inches
+ * - a suffixed value carries its own unit, so it bypasses the inches-vs-EMU magnitude heuristic entirely
+ * @param {string} value - ex: `'2.5cm'`, `'18pt'`
+ * @returns {number|undefined} inches, or `undefined` when `value` is not a suffixed length
+ */
+export function parseUnitLength (value: string): number | undefined {
+	const match = REGEX_UNIT_LENGTH.exec(value)
+	if (!match) return undefined
+	const num = Number(match[1])
+	if (!Number.isFinite(num)) return undefined
+	return num / UNITS_PER_INCH[match[2].toLowerCase()]
+}
+
 /**
  * Translates any type of `x`/`y`/`w`/`h` prop to EMU
  * - guaranteed to return a result regardless of undefined, null, etc. (0)
  * - {number} - 12800 (EMU)
  * - {number} - 0.5 (inches)
  * - {string} - "75%"
- * @param {number|string} size - numeric ("5.5") or percentage ("90%")
+ * - {string} - "2.5cm" (also in/mm/pt)
+ * @param {number|string} size - numeric ("5.5"), unit-suffixed ("2.5cm") or percentage ("90%")
  * @param {'X' | 'Y'} xyDir - direction
  * @param {PresLayout} layout - presentation layout
  * @returns {number} calculated size
@@ -207,7 +232,13 @@ export function getSmartParseNumber (size: Coord | undefined, xyDir: 'X' | 'Y', 
 	// Assume any number whose absolute value is 100+ is EMU already.
 	if (typeof size === 'number' && Math.abs(size) >= 100) return size
 
-	// CASE 3: Percentage (ex: '50%')
+	// CASE 3: Unit-suffixed length (ex: '2.5cm') - unambiguous, so no magnitude heuristic
+	if (typeof size === 'string') {
+		const inches = parseUnitLength(size)
+		if (inches !== undefined) return Math.round(EMU * inches)
+	}
+
+	// CASE 4: Percentage (ex: '50%')
 	if (typeof size === 'string' && size.includes('%')) {
 		if (xyDir && xyDir === 'X') return Math.round((parseFloat(size) / 100) * layout.width)
 		if (xyDir && xyDir === 'Y') return Math.round((parseFloat(size) / 100) * layout.height)
@@ -285,6 +316,11 @@ export function validateXmlFragment (xml: string): string | null {
  * @returns {number} EMU value
  */
 export function inch2Emu (inches: number | string): number {
+	// A unit-suffixed string states its own unit - convert it before any inches assumption
+	if (typeof inches === 'string') {
+		const parsed = parseUnitLength(inches)
+		if (parsed !== undefined) return Math.round(EMU * parsed)
+	}
 	// NOTE: Provide Caller Safety: Numbers may get conv<->conv during flight, so be kind and do some simple checks to ensure inches were passed
 	// Any absolute value over 100 is not inches (negative EMU is off-slide), so return it unchanged
 	if (typeof inches === 'number' && Math.abs(inches) > 100) return inches

--- a/src/pptxgen.ts
+++ b/src/pptxgen.ts
@@ -87,8 +87,15 @@ import {
 	AddSlideProps,
 	CompressionLevel,
 	ChangesInfoProps,
+	Color,
 	CommentAuthorProps,
 	DefineLayoutProps,
+	DocumentProps,
+	KinsokuProps,
+	PhotoAlbumProps,
+	PrintProps,
+	SlideSizeType,
+	ViewProps,
 	GuideProps,
 	IPresentationProps,
 	MediaOnError,
@@ -367,6 +374,20 @@ export default class PptxGenJS implements IPresentationProps {
 	 * @example pptx.notesGuides = [{ orient: 'horz', pos: 2 }]
 	 */
 	public notesGuides: GuideProps[] = []
+	/** Additional document properties written to `docProps`. */
+	public documentProps?: DocumentProps
+	/** Slide-size preset (`p:sldSz@type`). */
+	public slideSizeType?: SlideSizeType
+	/** Photo-album mode (`p:photoAlbum`). */
+	public photoAlbum?: PhotoAlbumProps
+	/** East Asian line-breaking rules (`p:kinsoku`). */
+	public kinsoku?: KinsokuProps
+	/** Print defaults (`p:prnPr` on `presentationPr`). */
+	public printProps?: PrintProps
+	/** Recently-used colours (`p:clrMru` on `presentationPr`). */
+	public recentColors?: Color[]
+	/** View properties (`ppt/viewProps.xml`). Unset keeps the previous hardcoded viewPr. */
+	public viewProps?: ViewProps
 
 	/**
 	 * Modern comment authors (MS-PPTX §2.16). Emitted to `ppt/authors.xml`.
@@ -720,8 +741,8 @@ export default class PptxGenJS implements IPresentationProps {
 			}
 			zip.file('[Content_Types].xml', genXml.makeXmlContTypes(this.slides, this.slideLayouts, this.masterSlide, trackingParts)) // TODO: pass only `this` like below! 20200206
 			zip.file('_rels/.rels', genXml.makeXmlRootRels())
-			zip.file('docProps/app.xml', genXml.makeXmlApp(this.slides, this.company)) // TODO: pass only `this` like below! 20200206
-			zip.file('docProps/core.xml', genXml.makeXmlCore(this.title, this.subject, this.author, this.revision, this.created, this.modified)) // TODO: pass only `this` like below! 20200206
+			zip.file('docProps/app.xml', genXml.makeXmlApp(this.slides, this.company, this.documentProps)) // TODO: pass only `this` like below! 20200206
+			zip.file('docProps/core.xml', genXml.makeXmlCore(this.title, this.subject, this.author, this.revision, this.created, this.modified, this.documentProps)) // TODO: pass only `this` like below! 20200206
 			zip.file('ppt/_rels/presentation.xml.rels', genXml.makeXmlPresentationRels(this.slides, trackingParts))
 			zip.file('ppt/theme/theme1.xml', genXml.makeXmlTheme(this))
 			// notesMaster gets its own theme part (Office repair creates theme2 when notesMaster shares theme1; Juliussssssss 9bdfe09).
@@ -729,7 +750,7 @@ export default class PptxGenJS implements IPresentationProps {
 			zip.file('ppt/presentation.xml', genXml.makeXmlPresentation(this))
 			zip.file('ppt/presProps.xml', genXml.makeXmlPresProps(this))
 			zip.file('ppt/tableStyles.xml', genXml.makeXmlTableStyles())
-			zip.file('ppt/viewProps.xml', genXml.makeXmlViewProps())
+			zip.file('ppt/viewProps.xml', genXml.makeXmlViewProps(this))
 
 			// C: Create a Layout/Master/Rel/Slide file for each SlideLayout and Slide
 			this.slideLayouts.forEach((layout, idx) => {
@@ -1038,6 +1059,14 @@ export default class PptxGenJS implements IPresentationProps {
 			_slideObjects: [],
 			background: propsClone.background || null,
 			bkgd: propsClone.bkgd || null,
+			layoutType: propsClone.layoutType,
+			matchingName: propsClone.matchingName,
+			preserve: propsClone.preserve,
+			showMasterShapes: propsClone.showMasterShapes,
+			showMasterPlaceholderAnimation: propsClone.showMasterPlaceholderAnimation,
+			userDrawn: propsClone.userDrawn,
+			colorMapOverride: propsClone.colorMapOverride,
+			transition: propsClone.transition,
 		}
 
 		// STEP 1: Create the Slide Master/Layout

--- a/src/xml/non-visual.ts
+++ b/src/xml/non-visual.ts
@@ -1,0 +1,92 @@
+/**
+ * PptxGenJS: Non-visual drawing properties (`p:cNvPr`) and editing locks
+ *
+ * Every drawable object carries a `p:cNvPr` with its id, name, and alt text, and a sibling
+ * `p:cNv*Pr` holding the lock element for its kind - `a:spLocks` for shapes, `a:picLocks` for
+ * pictures, `a:graphicFrameLocks` for frames, `a:grpSpLocks` for groups, `a:cxnSpLocks` for
+ * connectors. The lock attributes are shared, so one emitter serves all five.
+ */
+
+import { NonVisualProps, ShapeLockProps } from '../core-interfaces'
+import { encodeXmlEntities } from '../gen-utils'
+
+/** Lock attribute names, in the order the schema declares them */
+const LOCK_ATTRS: Array<[keyof ShapeLockProps, string]> = [
+	['noGroup', 'noGrp'],
+	['noSelect', 'noSelect'],
+	['noRotate', 'noRot'],
+	['noChangeAspect', 'noChangeAspect'],
+	['noMove', 'noMove'],
+	['noResize', 'noResize'],
+	['noEditPoints', 'noEditPoints'],
+	['noAdjustHandles', 'noAdjustHandles'],
+	['noChangeArrowheads', 'noChangeArrowheads'],
+	['noChangeShapeType', 'noChangeShapeType'],
+	['noTextEdit', 'noTextEdit'],
+	['noCrop', 'noCrop'],
+]
+
+/** Which lock attributes each element actually permits */
+const ALLOWED: Record<string, Set<string>> = {
+	'a:spLocks': new Set(['noGrp', 'noSelect', 'noRot', 'noChangeAspect', 'noMove', 'noResize', 'noEditPoints', 'noAdjustHandles', 'noChangeArrowheads', 'noChangeShapeType', 'noTextEdit']),
+	'a:picLocks': new Set(['noGrp', 'noSelect', 'noRot', 'noChangeAspect', 'noMove', 'noResize', 'noEditPoints', 'noAdjustHandles', 'noChangeArrowheads', 'noChangeShapeType', 'noCrop']),
+	'a:graphicFrameLocks': new Set(['noGrp', 'noSelect', 'noChangeAspect', 'noMove', 'noResize', 'noDrilldown']),
+	'a:grpSpLocks': new Set(['noGrp', 'noSelect', 'noRot', 'noChangeAspect', 'noMove', 'noResize', 'noUngrp']),
+	'a:cxnSpLocks': new Set(['noGrp', 'noSelect', 'noRot', 'noChangeAspect', 'noMove', 'noResize', 'noEditPoints', 'noAdjustHandles', 'noChangeArrowheads', 'noChangeShapeType']),
+}
+
+/**
+ * Create a lock element, or `''` when nothing is locked
+ * - attributes the element does not permit are dropped: an unexpected one is a schema violation
+ * @param {string} tag - lock element name for the object's kind
+ * @param {ShapeLockProps} lock - lock props
+ * @param {string} defaults - attributes the library already emits for this object
+ * @returns {string} XML string
+ */
+export function genXmlLocks (tag: string, lock?: ShapeLockProps, defaults = ''): string {
+	const allowed = ALLOWED[tag] ?? new Set<string>()
+	let attrs = defaults
+
+	LOCK_ATTRS.forEach(([prop, attr]) => {
+		if (lock?.[prop] !== true) return
+		if (!allowed.has(attr)) {
+			console.warn(`[pptxgenjs] \`${String(prop)}\` does not apply to this object type - ignored`)
+			return
+		}
+		// do not repeat an attribute the caller already gets by default
+		if (defaults.includes(`${attr}="`)) return
+		attrs += ` ${attr}="1"`
+	})
+
+	return attrs ? `<${tag}${attrs}/>` : ''
+}
+
+/**
+ * Create the `p:cNvPr` element
+ * @param {number} id - shape id, unique on the slide
+ * @param {string} name - shape name shown in the selection pane (already XML-escaped by callers)
+ * @param {NonVisualProps} props - non-visual options
+ * @param {string} descr - alt-text description
+ * @param {string} children - child elements (ex: hyperlinks); self-closes when empty
+ * @returns {string} XML string
+ */
+export function genXmlCNvPr (id: number, name: string, props?: NonVisualProps, descr = '', children = ''): string {
+	let attrs = `id="${id}" name="${name}"`
+	// `descr` is the alt-text description; `title` is the separate alt-text title
+	if (descr) attrs += ` descr="${encodeXmlEntities(descr)}"`
+	if (props?.title) attrs += ` title="${encodeXmlEntities(props.title)}"`
+	if (props?.hidden === true) attrs += ' hidden="1"'
+
+	return children ? `<p:cNvPr ${attrs}>${children}</p:cNvPr>` : `<p:cNvPr ${attrs}/>`
+}
+
+/**
+ * Create `p:cNvSpPr`, carrying the text-box flag and any shape locks
+ * @param {object} options - shape options
+ * @returns {string} XML string
+ */
+export function genXmlCNvSpPr (options: { isTextBox?: boolean, lock?: ShapeLockProps }): string {
+	const txBox = options?.isTextBox ? ' txBox="1"' : ''
+	const locks = genXmlLocks('a:spLocks', options?.lock)
+	return locks ? `<p:cNvSpPr${txBox}>${locks}</p:cNvSpPr>` : `<p:cNvSpPr${txBox}/>`
+}

--- a/src/xml/package.ts
+++ b/src/xml/package.ts
@@ -2,10 +2,12 @@
  * OOXML package-part rendering.
  */
 
-import { CRLF, EMU, LAYOUT_IDX_SERIES_BASE, SLDNUMFLDID, SLIDE_OBJECT_TYPES } from '../core-enums'
+import { CRLF, DEF_COLOR_MAP, EMU, LAYOUT_IDX_SERIES_BASE, SLDNUMFLDID, SLIDE_OBJECT_TYPES } from '../core-enums'
 import {
 	AnimationConfig,
 	AnimationType,
+	ColorMapOverrideProps,
+	DocumentProps,
 	GuideProps,
 	IPresentationProps,
 	PresSlide,
@@ -19,7 +21,7 @@ import {
 import { createTimingXml, MediaPlaybackEntry } from '../gen-animations'
 import { genXmlTransition } from '../gen-transition'
 import { AUTHOR_PART_CONTENT_TYPE, AUTHOR_REL_TYPE, COMMENT_PART_CONTENT_TYPE, COMMENT_REL_URI, P188_NS } from '../gen-comments'
-import { createColorElement, encodeXmlEntities, getUuid, resolveThemeColors } from '../gen-utils'
+import { createColorElement, encodeXmlEntities, getUuid, inch2Emu, resolveThemeColors } from '../gen-utils'
 import { extPartPackagePath } from './content-parts'
 import { slideCommentsRelId } from './relationships'
 import { resolveZoomSections, slideObjectToXml } from './slide'
@@ -214,22 +216,38 @@ export function makeXmlRootRels (): string {
 }
 
 /**
+ * Count text paragraphs across the deck for `app.xml`
+ * - derived rather than exposed: the value is a fact about the deck, not a caller preference
+ * @param {PresSlide[]} slides - presentation slides
+ * @returns {number} paragraph count
+ */
+function countParagraphs (slides: PresSlide[]): number {
+	return slides.reduce((total, slide) => total + (slide._slideObjects ?? []).reduce((count, obj) => {
+		if (obj._type !== SLIDE_OBJECT_TYPES.text && obj._type !== SLIDE_OBJECT_TYPES.placeholder) return count
+		return count + Math.max(1, (obj.text ?? []).length)
+	}, 0), 0)
+}
+
+/**
  * Creates `docProps/app.xml`
  * @param {PresSlide[]} slides - Presenation Slides
  * @param {string} company - "Company" metadata
+ * @param {DocumentProps} [props] - optional extended properties
  * @returns XML
  */
-export function makeXmlApp (slides: PresSlide[], company: string): string {
+export function makeXmlApp (slides: PresSlide[], company: string, props?: DocumentProps): string {
 	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
-	<TotalTime>0</TotalTime>
+	${props?.template ? `<Template>${encodeXmlEntities(props.template)}</Template>` : ''}
+	${props?.manager ? `<Manager>${encodeXmlEntities(props.manager)}</Manager>` : ''}
+	<TotalTime>${typeof props?.totalEditTime === 'number' && isFinite(props.totalEditTime) && props.totalEditTime >= 0 ? Math.round(props.totalEditTime) : 0}</TotalTime>
 	<Words>0</Words>
 	<Application>Microsoft Office PowerPoint</Application>
 	<PresentationFormat>On-screen Show (16:9)</PresentationFormat>
-	<Paragraphs>0</Paragraphs>
+	<Paragraphs>${countParagraphs(slides)}</Paragraphs>
 	<Slides>${slides.length}</Slides>
-	<Notes>${slides.length}</Notes>
-	<HiddenSlides>0</HiddenSlides>
-	<MMClips>0</MMClips>
+	<Notes>${slides.filter(slide => (slide._slideObjects ?? []).some(obj => obj._type === SLIDE_OBJECT_TYPES.notes)).length}</Notes>
+	<HiddenSlides>${slides.filter(slide => slide.hidden).length}</HiddenSlides>
+	<MMClips>${slides.reduce((sum, slide) => sum + (slide._slideObjects ?? []).filter(obj => obj._type === SLIDE_OBJECT_TYPES.media).length, 0)}</MMClips>
 	<ScaleCrop>false</ScaleCrop>
 	<HeadingPairs>
 		<vt:vector size="6" baseType="variant">
@@ -252,6 +270,7 @@ export function makeXmlApp (slides: PresSlide[], company: string): string {
 	<Company>${encodeXmlEntities(company)}</Company>
 	<LinksUpToDate>false</LinksUpToDate>
 	<SharedDoc>false</SharedDoc>
+	${props?.hyperlinkBase ? `<HyperlinkBase>${encodeXmlEntities(props.hyperlinkBase)}</HyperlinkBase>` : ''}
 	<HyperlinksChanged>false</HyperlinksChanged>
 	<AppVersion>16.0000</AppVersion>
 	</Properties>`
@@ -265,15 +284,24 @@ export function makeXmlApp (slides: PresSlide[], company: string): string {
  * @param {string} revision - metadata value
  * @param {Date} [created] - OPC `dcterms:created` (defaults to now)
  * @param {Date} [modified] - OPC `dcterms:modified` (defaults to now)
+ * @param {DocumentProps} [props] - optional extra core properties
  * @returns XML
  */
-export function makeXmlCore (title: string, subject: string, author: string, revision: string, created?: Date, modified?: Date): string {
+export function makeXmlCore (title: string, subject: string, author: string, revision: string, created?: Date, modified?: Date, props?: DocumentProps): string {
 	const createdAt = (created ?? new Date()).toISOString().replace(/\.\d\d\dZ/, 'Z')
 	const modifiedAt = (modified ?? new Date()).toISOString().replace(/\.\d\d\dZ/, 'Z')
 	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 	<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		<dc:title>${encodeXmlEntities(title)}</dc:title>
 		<dc:subject>${encodeXmlEntities(subject)}</dc:subject>
+		${props?.description ? `<dc:description>${encodeXmlEntities(props.description)}</dc:description>` : ''}
+		${props?.keywords ? `<cp:keywords>${encodeXmlEntities(props.keywords)}</cp:keywords>` : ''}
+		${props?.category ? `<cp:category>${encodeXmlEntities(props.category)}</cp:category>` : ''}
+		${props?.contentStatus ? `<cp:contentStatus>${encodeXmlEntities(props.contentStatus)}</cp:contentStatus>` : ''}
+		${props?.version ? `<cp:version>${encodeXmlEntities(props.version)}</cp:version>` : ''}
+		${props?.language ? `<dc:language>${encodeXmlEntities(props.language)}</dc:language>` : ''}
+		${props?.identifier ? `<dc:identifier>${encodeXmlEntities(props.identifier)}</dc:identifier>` : ''}
+		${props?.lastPrinted ? `<cp:lastPrinted>${encodeXmlEntities(props.lastPrinted)}</cp:lastPrinted>` : ''}
 		<dc:creator>${encodeXmlEntities(author)}</dc:creator>
 		<cp:lastModifiedBy>${encodeXmlEntities(author)}</cp:lastModifiedBy>
 		<cp:revision>${revision}</cp:revision>
@@ -503,10 +531,30 @@ export function makeXmlNotesSlide (slide: PresSlide): string {
  * @return {string} XML
  */
 export function makeXmlLayout (layout: SlideLayout): string {
+	// `preserve` has always been written as "1", so it stays on unless the caller turns it off
+	let attrs = layout.preserve === false ? '' : ' preserve="1"'
+	if (layout.layoutType) attrs += ` type="${layout.layoutType}"`
+	if (layout.matchingName) attrs += ` matchingName="${encodeXmlEntities(layout.matchingName)}"`
+	// both default to true in the schema, so only the "off" case is written
+	if (layout.showMasterShapes === false) attrs += ' showMasterSp="0"'
+	if (layout.showMasterPlaceholderAnimation === false) attrs += ' showMasterPhAnim="0"'
+	if (layout.userDrawn === true) attrs += ' userDrawn="1"'
+
+	// CT_ColorMapping requires all twelve attributes, so a partial override is filled from the
+	// identity map - which is exactly what inheriting `a:masterClrMapping` means
+	const clrMapOvr = layout.colorMapOverride
+		? `<p:clrMapOvr><a:overrideClrMapping${Object.entries(DEF_COLOR_MAP).map(([slot, fallback]) => ` ${slot}="${layout.colorMapOverride?.[slot as keyof ColorMapOverrideProps] ?? fallback}"`).join('')}/></p:clrMapOvr>`
+		: '<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>'
+
+	const transitionXml = genXmlTransition(layout)
+	const hasP14 = transitionXml.includes('p14:') || transitionXml.includes('xmlns:p14')
+	const ns = hasP14 ? ` xmlns:p14="${P14_NS}"` : ''
+
+	// CT_SlideLayout sequence: cSld, clrMapOvr, transition, timing, hf, extLst
 	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-		<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" preserve="1">
+		<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"${ns}${attrs}>
 		${slideObjectToXml(layout)}
-		<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sldLayout>`
+		${clrMapOvr}${transitionXml}</p:sldLayout>`
 }
 
 /**
@@ -649,8 +697,27 @@ export function makeXmlPresentation (pres: IPresentationProps): string {
 	strXml += `<p:notesMasterIdLst><p:notesMasterId r:id="rId${pres.slides.length + 2}"/></p:notesMasterIdLst>`
 
 	// STEP 4: Add sizes
-	strXml += `<p:sldSz cx="${pres.presLayout.width}" cy="${pres.presLayout.height}"/>`
+	// `@type` records which preset the dimensions match; omitted when the caller does not say
+	strXml += `<p:sldSz cx="${pres.presLayout.width}" cy="${pres.presLayout.height}"${pres.slideSizeType ? ` type="${pres.slideSizeType}"` : ''}/>`
 	strXml += `<p:notesSz cx="${pres.presLayout.height}" cy="${pres.presLayout.width}"/>`
+
+	// CT_Presentation sequence puts these between `notesSz` and `defaultTextStyle` (photoAlbum, kinsoku)
+	if (pres.photoAlbum) {
+		const album = pres.photoAlbum
+		let attrs = ''
+		if (album.blackWhite === true) attrs += ' bw="1"'
+		if (album.showCaptions === true) attrs += ' showCaptions="1"'
+		if (album.layout) attrs += ` layout="${album.layout}"`
+		if (album.frame) attrs += ` frame="${album.frame}"`
+		strXml += `<p:photoAlbum${attrs}/>`
+	}
+	// `invalStChars` and `invalEndChars` are required on CT_Kinsoku, so a partial value is dropped
+	// rather than emitted as an element PowerPoint would refuse to open
+	if (pres.kinsoku?.invalidStartChars && pres.kinsoku.invalidEndChars) {
+		const kin = pres.kinsoku
+		const lang = kin.lang ? ` lang="${encodeXmlEntities(kin.lang)}"` : ''
+		strXml += `<p:kinsoku${lang} invalStChars="${encodeXmlEntities(kin.invalidStartChars)}" invalEndChars="${encodeXmlEntities(kin.invalidEndChars)}"/>`
+	}
 
 	// STEP 5: Add text styles
 	strXml += '<p:defaultTextStyle>'
@@ -696,14 +763,34 @@ export function makeXmlPresentation (pres: IPresentationProps): string {
  * @return {string} XML
  */
 export function makeXmlPresProps (pres?: IPresentationProps): string {
-	// CT_PresentationProperties sequence: showPr then extLst. Opt-in: emit nothing extra unless set.
+	// CT_PresentationProperties sequence: htmlPubPr, webPr, prnPr, showPr, clrMru, extLst.
+	// Opt-in: emit nothing extra unless set. prnPr/clrMru live here (not on CT_Presentation).
+	const prnPr = makeXmlPrnPr(pres)
 	const showPr = makeXmlShowPr(pres)
+	const clrMru = makeXmlClrMru(pres)
 	const extLst = makeXmlPresPropsExtLst(pres)
 	return (
 		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}` +
 		'<p:presentationPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">' +
-		`${showPr}${extLst}</p:presentationPr>`
+		`${prnPr}${showPr}${clrMru}${extLst}</p:presentationPr>`
 	)
+}
+
+function makeXmlPrnPr (pres?: IPresentationProps): string {
+	if (!pres?.printProps) return ''
+	const prn = pres.printProps
+	let attrs = ''
+	if (prn.what) attrs += ` prnWhat="${prn.what}"`
+	if (prn.colorMode) attrs += ` clrMode="${prn.colorMode}"`
+	if (prn.hiddenSlides === true) attrs += ' hiddenSlides="1"'
+	if (prn.scaleToFitPaper === true) attrs += ' scaleToFitPaper="1"'
+	if (prn.frameSlides === true) attrs += ' frameSlides="1"'
+	return `<p:prnPr${attrs}/>`
+}
+
+function makeXmlClrMru (pres?: IPresentationProps): string {
+	if (!Array.isArray(pres?.recentColors) || pres.recentColors.length === 0) return ''
+	return `<p:clrMru>${pres.recentColors.map(color => createColorElement(color)).join('')}</p:clrMru>`
 }
 
 /**
@@ -766,8 +853,39 @@ export function makeXmlTableStyles (): string {
 
 /**
  * Creates `ppt/viewProps.xml`
+ * - the hardcoded literal is kept when the caller sets no `viewProps`, so default packages stay byte-identical
  * @return {string} XML
  */
-export function makeXmlViewProps (): string {
-	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}<p:viewPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:normalViewPr horzBarState="maximized"><p:restoredLeft sz="15611"/><p:restoredTop sz="94610"/></p:normalViewPr><p:slideViewPr><p:cSldViewPr snapToGrid="0" snapToObjects="1"><p:cViewPr varScale="1"><p:scale><a:sx n="136" d="100"/><a:sy n="136" d="100"/></p:scale><p:origin x="216" y="312"/></p:cViewPr><p:guideLst/></p:cSldViewPr></p:slideViewPr><p:notesTextViewPr><p:cViewPr><p:scale><a:sx n="1" d="1"/><a:sy n="1" d="1"/></p:scale><p:origin x="0" y="0"/></p:cViewPr></p:notesTextViewPr><p:gridSpacing cx="76200" cy="76200"/></p:viewPr>`
+export function makeXmlViewProps (pres?: IPresentationProps): string {
+	if (!pres?.viewProps) {
+		return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}<p:viewPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:normalViewPr horzBarState="maximized"><p:restoredLeft sz="15611"/><p:restoredTop sz="94610"/></p:normalViewPr><p:slideViewPr><p:cSldViewPr snapToGrid="0" snapToObjects="1"><p:cViewPr varScale="1"><p:scale><a:sx n="136" d="100"/><a:sy n="136" d="100"/></p:scale><p:origin x="216" y="312"/></p:cViewPr><p:guideLst/></p:cSldViewPr></p:slideViewPr><p:notesTextViewPr><p:cViewPr><p:scale><a:sx n="1" d="1"/><a:sy n="1" d="1"/></p:scale><p:origin x="0" y="0"/></p:cViewPr></p:notesTextViewPr><p:gridSpacing cx="76200" cy="76200"/></p:viewPr>`
+	}
+
+	const view = pres.viewProps
+	const zoom = typeof view.zoom === 'number' && isFinite(view.zoom) && view.zoom > 0 ? Math.round(view.zoom) : 136
+	const grid = typeof view.gridSpacing === 'number' && isFinite(view.gridSpacing) && view.gridSpacing > 0 ? inch2Emu(view.gridSpacing) : 76200
+	const snapGrid = view.snapToGrid === true ? '1' : '0'
+	const snapObj = view.snapToObjects === false ? '0' : '1'
+	const showGuides = view.showGuides === true ? ' showGuides="1"' : ''
+	const showComments = view.showComments === false ? ' showComments="0"' : ''
+	const lastView = view.lastView ? ` lastView="${view.lastView}"` : ''
+
+	// `p:guideLst` is the classic guide list, distinct from the MS-PPTX `p15:sldGuideLst` extension
+	const guides = (view.guides ?? [])
+		.filter((guide): guide is GuideProps & { pos: number } => typeof guide.pos === 'number' && isFinite(guide.pos) && guide.pos >= 0)
+		.map(guide => `<p:guide${guide.orient === 'vert' ? ' orient="vert"' : ''} pos="${Math.round(guide.pos * 96)}"/>`)
+		.join('')
+
+	return (
+		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}` +
+		`<p:viewPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"${lastView}${showComments}>` +
+		'<p:normalViewPr horzBarState="maximized"><p:restoredLeft sz="15611"/><p:restoredTop sz="94610"/></p:normalViewPr>' +
+		`<p:slideViewPr><p:cSldViewPr snapToGrid="${snapGrid}" snapToObjects="${snapObj}"${showGuides}>` +
+		`<p:cViewPr varScale="1"><p:scale><a:sx n="${zoom}" d="100"/><a:sy n="${zoom}" d="100"/></p:scale><p:origin x="216" y="312"/></p:cViewPr>` +
+		(guides ? `<p:guideLst>${guides}</p:guideLst>` : '<p:guideLst/>') +
+		'</p:cSldViewPr></p:slideViewPr>' +
+		'<p:notesTextViewPr><p:cViewPr><p:scale><a:sx n="1" d="1"/><a:sy n="1" d="1"/></p:scale><p:origin x="0" y="0"/></p:cViewPr></p:notesTextViewPr>' +
+		`<p:gridSpacing cx="${grid}" cy="${grid}"/>` +
+		'</p:viewPr>'
+	)
 }

--- a/src/xml/slide.ts
+++ b/src/xml/slide.ts
@@ -45,6 +45,7 @@ import {
 import { getImagePixelSize } from '../gen-media'
 import { genXmlCreationIdExt, genXmlModIdExt, TABLE_MOD_ID_BASE } from '../gen-revision'
 import { genXmlContentPartAlternate, genXmlOfficeAppAlternate } from './content-parts'
+import { genXmlCNvPr, genXmlCNvSpPr, genXmlLocks } from './non-visual'
 import { genXmlNvPrExtLst, genXmlPlaceholder, genXmlTextBody, textRunsHaveOmml } from './text'
 
 function nvPrModIdExt (modId?: number): string {
@@ -52,7 +53,15 @@ function nvPrModIdExt (modId?: number): string {
 }
 
 function genXmlNvPr (options?: ObjectOptions, phXml = '', extraExts: string[] = []): string {
-	return `<p:nvPr>${phXml}${genXmlNvPrExtLst(options, extraExts)}</p:nvPr>`
+	return `<p:nvPr${options?.userDrawn === true ? ' userDrawn="1"' : ''}>${phXml}${genXmlNvPrExtLst(options, extraExts)}</p:nvPr>`
+}
+
+function genXmlCNvPrHlinks (hlink?: { url?: string, slide?: number, _rId?: number, tooltip?: string }): string {
+	if (!hlink?._rId) return ''
+	const tip = hlink.tooltip ? encodeXmlEntities(hlink.tooltip) : ''
+	if (hlink.url) return `<a:hlinkClick r:id="rId${hlink._rId}" tooltip="${tip}"/>`
+	if (hlink.slide) return `<a:hlinkClick r:id="rId${hlink._rId}" tooltip="${tip}" action="ppaction://hlinksldjump"/>`
+	return ''
 }
 
 const ImageSizingXml = {
@@ -583,13 +592,13 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 
 					// STEP 1: Start Table XML
 					// NOTE: Non-numeric cNvPr id values will trigger "presentation needs repair" type warning in MS-PPT-2013
-					strXml = `<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="${intTableNum * (slide._slideNum ?? 0) + 1}" name="${slideItemObj.options.objectName}"/>`
+					strXml = '<p:graphicFrame><p:nvGraphicFramePr>' + genXmlCNvPr(intTableNum * (slide._slideNum ?? 0) + 1, String(slideItemObj.options.objectName ?? ''), slideItemObj.options)
 					// When the table binds to a master/layout placeholder, emit `<p:ph type="tbl"/>` (ECMA-376 §4.4.1.33, issue #856)
 					const tblPh = placeholderObj ? genXmlPlaceholder(placeholderObj, slideItemObj.options) : ''
 					// MS-PPTX §2.3.1.19: each p14:modId must be unique on the slide (not a constant).
 					const tableModId = typeof slideItemObj.options.modId === 'number' ? slideItemObj.options.modId : TABLE_MOD_ID_BASE + idx
 					strXml +=
-						'<p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr>' +
+						`<p:cNvGraphicFramePr>${genXmlLocks('a:graphicFrameLocks', slideItemObj.options.lock, ' noGrp="1"')}</p:cNvGraphicFramePr>` +
 					`  ${genXmlNvPr(slideItemObj.options, tblPh, [nvPrModIdExt(tableModId)])}` +
 					'</p:nvGraphicFramePr>'
 					strXml += `<p:xfrm><a:off x="${x || (x === 0 ? 0 : EMU)}" y="${y || (y === 0 ? 0 : EMU)}"/><a:ext cx="${cx || (cx === 0 ? 0 : EMU)}" cy="${cy || EMU
@@ -672,8 +681,10 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 						const itemOpts: ObjectOptions = slideItemObj.options ?? {}
 						// A: Table Height provided without rowH? Then distribute rows
 						let intRowH = 0 // IMPORTANT: Default must be zero for auto-sizing to work
-						if (Array.isArray(objTabOpts.rowH) && objTabOpts.rowH[rIdx]) intRowH = inch2Emu(Number(objTabOpts.rowH[rIdx]))
-						else if (objTabOpts.rowH && !isNaN(Number(objTabOpts.rowH))) intRowH = inch2Emu(Number(objTabOpts.rowH))
+						// `rowH` is either one value for every row or a per-row array; `inch2Emu` resolves inches, EMU and unit-suffixed strings alike
+						const rowHOpt = Array.isArray(objTabOpts.rowH) ? objTabOpts.rowH[rIdx] : objTabOpts.rowH
+						const rowHEmu = rowHOpt ? inch2Emu(rowHOpt) : NaN
+						if (!isNaN(rowHEmu)) intRowH = rowHEmu
 						else if (itemOpts.cy || itemOpts.h) {
 							intRowH = Math.round(
 								(itemOpts.h ? inch2Emu(itemOpts.h) : typeof itemOpts.cy === 'number' ? itemOpts.cy : 1) /
@@ -829,25 +840,18 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					// A: Start SHAPE / CONNECTOR ============================================
 					if (isConnector) {
 						strSlideXml += '<p:cxnSp>'
-						strSlideXml += `<p:nvCxnSpPr><p:cNvPr id="${shapeId}" name="${slideItemObj.options.objectName}"></p:cNvPr>`
-						strSlideXml += `<p:cNvCxnSpPr><a:stCxn id="${slideItemObj.options.line?.sourceId}" idx="${slideItemObj.options.line?.sourceAnchorPos ?? 0}"/><a:endCxn id="${slideItemObj.options.line?.targetId}" idx="${slideItemObj.options.line?.targetAnchorPos ?? 0}"/></p:cNvCxnSpPr>`
+						strSlideXml += `<p:nvCxnSpPr>${genXmlCNvPr(shapeId, String(slideItemObj.options.objectName ?? ''), slideItemObj.options)}`
+						const cxnLocks = genXmlLocks('a:cxnSpLocks', slideItemObj.options.lock)
+						strSlideXml += `<p:cNvCxnSpPr>${cxnLocks}<a:stCxn id="${slideItemObj.options.line?.sourceId}" idx="${slideItemObj.options.line?.sourceAnchorPos ?? 0}"/><a:endCxn id="${slideItemObj.options.line?.targetId}" idx="${slideItemObj.options.line?.targetAnchorPos ?? 0}"/></p:cNvCxnSpPr>`
 						strSlideXml += `${genXmlNvPr(slideItemObj.options, '', [nvPrModIdExt(slideItemObj.options.modId)])}</p:nvCxnSpPr><p:spPr>`
 					} else {
 						strSlideXml += '<p:sp>'
 						// B: The addition of the "txBox" attribute is the sole determiner of if an object is a shape or textbox
-						strSlideXml += `<p:nvSpPr><p:cNvPr id="${shapeId}" name="${slideItemObj.options.objectName}">`
-						// <Hyperlink>
-						if (slideItemObj.options.hyperlink?.url) {
-							strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.options.hyperlink._rId}" tooltip="${slideItemObj.options.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.options.hyperlink.tooltip) : ''}"/>`
-						}
-						if (slideItemObj.options.hyperlink?.slide) {
-							strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.options.hyperlink._rId}" tooltip="${slideItemObj.options.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.options.hyperlink.tooltip) : ''}" action="ppaction://hlinksldjump"/>`
-						}
-						// </Hyperlink>
-						strSlideXml += '</p:cNvPr>'
+						strSlideXml += '<p:nvSpPr>' + genXmlCNvPr(shapeId, String(slideItemObj.options.objectName ?? ''), slideItemObj.options, '',
+							genXmlCNvPrHlinks(slideItemObj.options.hyperlink))
 						// PowerPoint math zones are authored in text boxes; force txBox when OMML is present
 						const useTxBox = Boolean(slideItemObj.options?.isTextBox) || textRunsHaveOmml(slideItemObj.text)
-						strSlideXml += '<p:cNvSpPr' + (useTxBox ? ' txBox="1"/>' : '/>')
+						strSlideXml += genXmlCNvSpPr({ ...slideItemObj.options, isTextBox: useTxBox })
 						strSlideXml += genXmlNvPr(
 							slideItemObj.options,
 							slideItemObj._type === 'placeholder' ? genXmlPlaceholder(slideItemObj, slideItemObj.options) : genXmlPlaceholder(placeholderObj, slideItemObj.options),
@@ -918,19 +922,10 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 				case SLIDE_OBJECT_TYPES.image:
 					strSlideXml += '<p:pic>'
 					strSlideXml += '  <p:nvPicPr>'
-					strSlideXml += `<p:cNvPr id="${shapeId}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(
-						slideItemObj.options.altText || slideItemObj.image
-					)}">`
-					if (slideItemObj.hyperlink?.url) {
-						strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.hyperlink._rId}" tooltip="${slideItemObj.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.hyperlink.tooltip) : ''
-						}"/>`
-					}
-					if (slideItemObj.hyperlink?.slide) {
-						strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.hyperlink._rId}" tooltip="${slideItemObj.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.hyperlink.tooltip) : ''
-						}" action="ppaction://hlinksldjump"/>`
-					}
-					strSlideXml += '    </p:cNvPr>'
-					strSlideXml += '    <p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr>'
+					strSlideXml += genXmlCNvPr(shapeId, String(slideItemObj.options.objectName ?? ''), slideItemObj.options, slideItemObj.options.altText || slideItemObj.image,
+						genXmlCNvPrHlinks(slideItemObj.hyperlink))
+					// `noChangeAspect` has always been emitted here; caller locks are added to it
+					strSlideXml += `    <p:cNvPicPr${slideItemObj.options.lock?.preferRelativeResize === true ? ' preferRelativeResize="1"' : ''}>${genXmlLocks('a:picLocks', slideItemObj.options.lock, ' noChangeAspect="1"')}</p:cNvPicPr>`
 					strSlideXml += genXmlNvPr(slideItemObj.options, genXmlPlaceholder(placeholderObj, slideItemObj.options), [nvPrModIdExt(slideItemObj.options.modId)])
 					strSlideXml += '  </p:nvPicPr>'
 					strSlideXml += '<p:blipFill>'
@@ -1156,8 +1151,9 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 				case SLIDE_OBJECT_TYPES.chart:
 					strSlideXml += '<p:graphicFrame>'
 					strSlideXml += ' <p:nvGraphicFramePr>'
-					strSlideXml += `   <p:cNvPr id="${shapeId}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(slideItemObj.options.altText || '')}"/>`
-					strSlideXml += '   <p:cNvGraphicFramePr/>'
+					strSlideXml += genXmlCNvPr(shapeId, String(slideItemObj.options.objectName ?? ''), slideItemObj.options, slideItemObj.options.altText || '')
+					const chartLocks = genXmlLocks('a:graphicFrameLocks', slideItemObj.options.lock)
+					strSlideXml += chartLocks ? `   <p:cNvGraphicFramePr>${chartLocks}</p:cNvGraphicFramePr>` : '   <p:cNvGraphicFramePr/>'
 					strSlideXml += genXmlNvPr(slideItemObj.options, genXmlPlaceholder(placeholderObj, slideItemObj.options), [nvPrModIdExt(slideItemObj.options.modId)])
 					strSlideXml += ' </p:nvGraphicFramePr>'
 					strSlideXml += ` <p:xfrm><a:off x="${x}" y="${y}"/><a:ext cx="${cx}" cy="${cy}"/></p:xfrm>`
@@ -1173,8 +1169,9 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 				// PresentationML `p:grpSp` (ECMA-376 §19.3.1.22): nvGrpSpPr + grpSpPr + children.
 				// Child coords are group-relative; chOff is 0,0 and chExt matches the group size.
 					strSlideXml += '<p:grpSp>'
-					strSlideXml += `<p:nvGrpSpPr><p:cNvPr id="${shapeId}" name="${encodeXmlEntities(slideItemObj.options.objectName || `Group ${shapeId}`)}"/>`
-					strSlideXml += '<p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>'
+					strSlideXml += `<p:nvGrpSpPr>${genXmlCNvPr(shapeId, slideItemObj.options.objectName || `Group ${shapeId}`, slideItemObj.options)}`
+					const grpLocks = genXmlLocks('a:grpSpLocks', slideItemObj.options.lock)
+					strSlideXml += (grpLocks ? `<p:cNvGrpSpPr>${grpLocks}</p:cNvGrpSpPr>` : '<p:cNvGrpSpPr/>') + `${genXmlNvPr(slideItemObj.options)}</p:nvGrpSpPr>`
 					strSlideXml += '<p:grpSpPr>'
 					strSlideXml += `<a:xfrm${locationAttr}>`
 					strSlideXml += `<a:off x="${x}" y="${y}"/><a:ext cx="${cx}" cy="${cy}"/>`

--- a/src/xml/text.ts
+++ b/src/xml/text.ts
@@ -798,9 +798,15 @@ export function genXmlPlaceholder (placeholderObj: ISlideObject | undefined, ext
 	const placeholderIdx = placeholderObj.options?._placeholderIdx ? placeholderObj.options._placeholderIdx : ''
 	const placeholderType = resolvePlaceholderType(placeholderObj.options?._placeholderType)
 
+	// `orient` and `sz` default to horz/full in the schema, so only a non-default is written
+	const placeholderOrient = placeholderObj.options?.orient === 'vert' ? ' orient="vert"' : ''
+	const placeholderSize = placeholderObj.options?.sz === 'half' || placeholderObj.options?.sz === 'quarter' ? ` sz="${placeholderObj.options.sz}"` : ''
+
 	const attrs =
 		`${placeholderIdx ? ' idx="' + placeholderIdx.toString() + '"' : ''}` +
 		`${placeholderType ? ` type="${placeholderType}"` : ''}` +
+		placeholderOrient +
+		placeholderSize +
 		`${placeholderObj.text && placeholderObj.text.length > 0 ? ' hasCustomPrompt="1"' : ''}`
 
 	const phTypeExt = extraOpts?.phTypeExt ?? placeholderObj.options?.phTypeExt

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -260,3 +260,73 @@ test('contract: rejects a comments part without a slide relationship', async () 
 	)
 	await assert.rejects(assertModernCommentPartContracts(invalidZip), /MUST be the target of an explicit relationship/)
 })
+
+const LOCK_PNG = 'image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAIAAADwyuo0AAAADklEQVR4nGP4jwQYkDkANvEX6SAXxcIAAAAASUVORK5CYII='
+
+test('contract: unit-suffixed lengths reach the slide XML as EMU', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addText('Metrisch', { x: '2.54cm', y: '25.4mm', w: '72pt', h: '1in' })
+	slide.addTable([['A', 'B']], { x: '2.54cm', y: 3, colW: ['2.54cm', '2.54cm'] as unknown as number[], rowH: '2.54cm' as unknown as number })
+	const unitZip = await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer)
+	const xml = await readPart(unitZip, 'ppt/slides/slide1.xml')
+
+	assert.doesNotMatch(xml, /NaN/, 'no coordinate resolved to NaN')
+	assert.match(xml, /<a:off x="914400" y="914400"\/><a:ext cx="914400" cy="914400"\/>/, 'cm/mm/pt/in all resolve to one inch')
+	assert.equal((xml.match(/<a:gridCol w="914400"\/>/g) ?? []).length, 2, 'colW tolerates suffixed lengths')
+	assert.match(xml, /<a:tr h="914400">/, 'rowH tolerates suffixed lengths')
+})
+
+test('contract: editing locks and non-visual properties are reachable', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addShape(pptx.ShapeType.rect, {
+		x: 1, y: 1, w: 2, h: 1,
+		objectName: 'Locked Box', title: 'Alt title', hidden: true,
+		lock: { noMove: true, noResize: true, noSelect: true, noTextEdit: true },
+	})
+	slide.addImage({ data: LOCK_PNG, x: 4, y: 1, w: 1, h: 1, lock: { noCrop: true, preferRelativeResize: true }, title: 'Pic title' })
+	slide.addTable([['a']], { x: 1, y: 3, w: 4, lock: { noSelect: true } })
+	const lockZip = await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer)
+	await assertPptxPackageContracts(lockZip)
+	const xml = await readPart(lockZip, 'ppt/slides/slide1.xml')
+
+	assert.doesNotMatch(xml, /NaN|undefined/, 'lock options must not leak invalid values')
+	assert.match(xml, /<p:cNvPr id="2" name="Locked Box" title="Alt title" hidden="1"\/>/, 'shape non-visual props missing')
+	assert.match(xml, /<a:spLocks noSelect="1" noMove="1" noResize="1" noTextEdit="1"\/>/, 'shape locks missing')
+	assert.match(xml, /<p:cNvPicPr preferRelativeResize="1"><a:picLocks noChangeAspect="1" noCrop="1"\/><\/p:cNvPicPr>/, 'picture locks missing')
+	assert.match(xml, /title="Pic title"/, 'picture alt title missing')
+	assert.match(xml, /<a:graphicFrameLocks noGrp="1" noSelect="1"\/>/, 'graphic frame locks missing')
+})
+
+test('contract: locks that do not apply to an object are dropped with a warning', async () => {
+	const warnings: string[] = []
+	const origWarn = console.warn
+	console.warn = (msg: string) => warnings.push(String(msg))
+	let xml = ''
+	try {
+		const pptx = new pptxgen()
+		pptx.addSlide().addTable([['a']], { x: 1, y: 1, w: 3, lock: { noTextEdit: true, noSelect: true } })
+		pptx.addSlide().addShape(pptx.ShapeType.rect, { x: 1, y: 1, w: 2, h: 1, lock: { noCrop: true, noMove: true } })
+		xml = await readPart(await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer), 'ppt/slides/slide1.xml')
+	} finally {
+		console.warn = origWarn
+	}
+
+	assert.equal(warnings.filter(w => w.includes('does not apply to this object type')).length, 2, 'inapplicable locks must warn')
+	assert.match(xml, /<a:graphicFrameLocks noGrp="1" noSelect="1"\/>/, 'the applicable lock must survive')
+	assert.doesNotMatch(xml, /noTextEdit/, 'an inapplicable lock must not be emitted')
+})
+
+test('contract: objects without locks keep the output they always had', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addShape(pptx.ShapeType.rect, { x: 1, y: 1, w: 2, h: 1 })
+	slide.addImage({ data: LOCK_PNG, x: 4, y: 1, w: 1, h: 1 })
+	slide.addTable([['a']], { x: 1, y: 3, w: 3 })
+	const xml = await readPart(await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer), 'ppt/slides/slide1.xml')
+
+	assert.doesNotMatch(xml, /a:spLocks|title=|hidden=|preferRelativeResize/, 'no lock or non-visual attribute may appear unasked')
+	assert.match(xml, /<p:cNvPicPr><a:picLocks noChangeAspect="1"\/><\/p:cNvPicPr>/, 'default picture lock changed')
+	assert.match(xml, /<a:graphicFrameLocks noGrp="1"\/>/, 'default frame lock changed')
+})

--- a/test/gen-utils.test.ts
+++ b/test/gen-utils.test.ts
@@ -98,6 +98,26 @@ test('getSmartParseNumber', () => {
 	assert.equal(getSmartParseNumber('garbage', 'X', LAYOUT), 0)
 })
 
+test('getSmartParseNumber accepts unit-suffixed lengths', () => {
+	assert.equal(getSmartParseNumber('2.54cm', 'X', LAYOUT), 914400, 'cm')
+	assert.equal(getSmartParseNumber('25.4mm', 'Y', LAYOUT), 914400, 'mm')
+	assert.equal(getSmartParseNumber('72pt', 'X', LAYOUT), 914400, 'pt')
+	assert.equal(getSmartParseNumber('1in', 'X', LAYOUT), 914400, 'in')
+	assert.equal(getSmartParseNumber('-1.27cm', 'X', LAYOUT), -457200, 'negative offsets are allowed')
+	assert.equal(getSmartParseNumber('300cm', 'X', LAYOUT), 108000000, 'a stated unit bypasses the inches-vs-EMU heuristic')
+	assert.equal(getSmartParseNumber('5px', 'X', LAYOUT), 0, 'unsupported units are not guessed at')
+	assert.equal(getSmartParseNumber('.5in', 'X', LAYOUT), 457200, 'a leading decimal point')
+	const digits = '0'.repeat(50000)
+	const start = process.hrtime.bigint()
+	assert.equal(getSmartParseNumber(`${digits}x`, 'X', LAYOUT), 0, 'a long non-matching digit string is rejected')
+	assert.ok(Number(process.hrtime.bigint() - start) / 1e6 < 100, 'and rejected in linear time, not by backtracking')
+})
+
+test('inch2Emu accepts unit-suffixed lengths', () => {
+	assert.equal(inch2Emu('2.54cm'), 914400, 'the inch-valued options (colW, rowH, inset, cell margin) share the parse')
+	assert.equal(inch2Emu('300cm'), 108000000, 'no magnitude heuristic when the unit is stated')
+})
+
 test('getUuid', () => {
 	assert.match(getUuid('xxxxxxxx'), /^[0-9a-f]{8}$/)
 	assert.match(getUuid('y'), /^[89ab]$/, 'the "y" nibble is constrained per RFC4122')

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -3507,3 +3507,130 @@ test('OMML: malformed omml option throws instead of writing a corrupt package', 
 	const xml = await readPart(await writeZip(pptx3), 'ppt/slides/slide1.xml')
 	assert.ok(xml.includes('a&lt;b&amp;c'), 'valid OMML was rejected or mangled')
 })
+
+test('#137/#136/#153: presentation, view and document properties reach their parts', async () => {
+	const pptx = new pptxgen()
+	pptx.documentProps = { category: 'Reports', contentStatus: 'Final', keywords: 'a, b', language: 'de-DE', version: '2.1', manager: 'Ada', template: 'Corp.potx', hyperlinkBase: 'https://x.test', totalEditTime: 42 }
+	pptx.slideSizeType = 'screen16x9'
+	pptx.photoAlbum = { blackWhite: true, layout: '2pic', frame: 'frameStyle3' }
+	pptx.kinsoku = { lang: 'ja-JP', invalidStartChars: ')]}', invalidEndChars: '([{' }
+	pptx.printProps = { what: 'handouts4', colorMode: 'gray', frameSlides: true }
+	pptx.recentColors = ['FF0000', 'accent1']
+	pptx.viewProps = { lastView: 'sldThumbnailView', showComments: false, zoom: 75, gridSpacing: 0.5, snapToGrid: true, snapToObjects: false }
+	const slide = pptx.addSlide()
+	slide.addText('one', { x: 1, y: 1 })
+	slide.addNotes('speaker note')
+	pptx.addSlide().hidden = true
+
+	const zip = await writeZip(pptx)
+	const core = await readPart(zip, 'docProps/core.xml')
+	for (const el of ['<cp:category>Reports</cp:category>', '<cp:contentStatus>Final</cp:contentStatus>', '<cp:keywords>a, b</cp:keywords>', '<dc:language>de-DE</dc:language>', '<cp:version>2.1</cp:version>']) {
+		assert.ok(core.includes(el), `core.xml missing ${el}`)
+	}
+
+	const app = await readPart(zip, 'docProps/app.xml')
+	for (const el of ['<Manager>Ada</Manager>', '<Template>Corp.potx</Template>', '<HyperlinkBase>https://x.test</HyperlinkBase>', '<TotalTime>42</TotalTime>', '<Notes>1</Notes>', '<HiddenSlides>1</HiddenSlides>', '<Paragraphs>1</Paragraphs>']) {
+		assert.ok(app.includes(el), `app.xml missing ${el}`)
+		const tag = /^<(\w+)>/.exec(el)?.[1] ?? ''
+		assert.equal((app.match(new RegExp(`<${tag}>`, 'g')) ?? []).length, 1, `app.xml emits <${tag}> more than once`)
+	}
+
+	const pres = await readPart(zip, 'ppt/presentation.xml')
+	assert.ok(pres.includes(' type="screen16x9"/>'), 'sldSz type missing')
+	assert.ok(pres.includes('<p:photoAlbum bw="1" layout="2pic" frame="frameStyle3"/>'), `photoAlbum wrong: ${pres.slice(0, 400)}`)
+	assert.ok(pres.includes('<p:kinsoku lang="ja-JP" invalStChars=")]}" invalEndChars="([{"/>'), 'kinsoku wrong')
+	// CT_Presentation order: photoAlbum/kinsoku sit between notesSz and defaultTextStyle
+	const order = ['<p:notesSz', '<p:photoAlbum', '<p:kinsoku', '<p:defaultTextStyle>'].map(tag => pres.indexOf(tag))
+	assert.deepEqual(order, [...order].sort((a, b) => a - b), `CT_Presentation child order violated: ${order.join(',')}`)
+
+	// prnPr / clrMru belong on CT_PresentationProperties, not CT_Presentation
+	const presPr = await readPart(zip, 'ppt/presProps.xml')
+	assert.ok(presPr.includes('<p:prnPr prnWhat="handouts4" clrMode="gray" frameSlides="1"/>'), 'prnPr wrong')
+	assert.ok(presPr.includes('<p:clrMru><a:srgbClr val="FF0000"/><a:schemeClr val="accent1"/></p:clrMru>'), 'clrMru wrong')
+	const propsOrder = ['<p:prnPr', '<p:clrMru>'].map(tag => presPr.indexOf(tag))
+	assert.deepEqual(propsOrder, [...propsOrder].sort((a, b) => a - b), `CT_PresentationProperties child order violated: ${propsOrder.join(',')}`)
+
+	const view = await readPart(zip, 'ppt/viewProps.xml')
+	assert.ok(view.includes('lastView="sldThumbnailView"'), 'lastView missing')
+	assert.ok(view.includes('showComments="0"'), 'showComments missing')
+	assert.ok(view.includes('<p:cSldViewPr snapToGrid="1" snapToObjects="0">'), `snap attrs wrong: ${view}`)
+	assert.ok(view.includes('<a:sx n="75" d="100"/>'), 'zoom missing')
+	assert.ok(view.includes('<p:gridSpacing cx="457200" cy="457200"/>'), 'gridSpacing missing')
+
+	const partial = new pptxgen()
+	partial.kinsoku = { lang: 'ja-JP' }
+	partial.addSlide()
+	assert.ok(!(await readPart(await writeZip(partial), 'ppt/presentation.xml')).includes('<p:kinsoku'), 'incomplete kinsoku was emitted')
+
+	const bare = new pptxgen()
+	bare.addSlide()
+	const bareZip = await writeZip(bare)
+	const barePres = await readPart(bareZip, 'ppt/presentation.xml')
+	for (const tag of ['<p:photoAlbum', '<p:kinsoku', 'type="']) assert.ok(!barePres.includes(tag), `default presentation.xml gained ${tag}`)
+	const barePresPr = await readPart(bareZip, 'ppt/presProps.xml')
+	for (const tag of ['<p:prnPr', '<p:clrMru']) assert.ok(!barePresPr.includes(tag), `default presProps.xml gained ${tag}`)
+	const bareView = await readPart(bareZip, 'ppt/viewProps.xml')
+	assert.ok(bareView.includes('<a:sx n="136" d="100"/>') && bareView.includes('<p:gridSpacing cx="76200" cy="76200"/>'), 'default viewProps.xml changed')
+	assert.ok(!bareView.includes('lastView=') && !bareView.includes('showComments='), 'default viewProps.xml gained attributes')
+})
+
+test('#149: slide layout and placeholder metadata', async () => {
+	const pptx = new pptxgen()
+	pptx.defineSlideMaster({
+		title: 'SECTION',
+		layoutType: 'secHead',
+		matchingName: 'Section Header',
+		showMasterShapes: false,
+		showMasterPlaceholderAnimation: false,
+		userDrawn: true,
+		colorMapOverride: { bg1: 'dk1', tx1: 'lt1' },
+		transition: { type: 'fade', duration: 500 },
+		objects: [{ placeholder: { options: { name: 'ttl', type: 'title', x: 1, y: 1, w: 6, h: 1, orient: 'vert', sz: 'half', userDrawn: true }, text: 'Section' } }],
+	})
+	pptx.defineSlideMaster({ title: 'PLAIN', preserve: false, objects: [{ placeholder: { options: { name: 'b', type: 'body', x: 1, y: 1, w: 6, h: 1 } } }] })
+	pptx.addSlide({ masterName: 'SECTION' })
+
+	const zip = await writeZip(pptx)
+	assert.ok((zip.file(/slideLayout\d+\.xml/) ?? []).length >= 2, 'expected layout parts')
+
+	let layout = ''
+	for (const file of zip.file(/ppt\/slideLayouts\/slideLayout\d+\.xml/) ?? []) {
+		const xml = await file.async('string')
+		if (xml.includes('type="secHead"')) layout = xml
+	}
+	assert.ok(layout, 'no layout carried the metadata')
+
+	assert.ok(layout.includes(' preserve="1" type="secHead" matchingName="Section Header" showMasterSp="0" showMasterPhAnim="0" userDrawn="1">'), `p:sldLayout attrs wrong: ${/<p:sldLayout[^>]*>/.exec(layout)?.[0] ?? ''}`)
+	assert.ok(layout.includes('<a:overrideClrMapping bg1="dk1" tx1="lt1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>'), `clrMapOvr wrong: ${/<p:clrMapOvr>[\s\S]*?<\/p:clrMapOvr>/.exec(layout)?.[0] ?? ''}`)
+
+	const seq = ['<p:cSld', '</p:cSld>', '<p:clrMapOvr>', '<p:transition'].map(tag => layout.indexOf(tag))
+	assert.ok(seq.every(idx => idx > -1), `a p:sldLayout child is missing: ${seq.join(',')}`)
+	assert.deepEqual(seq, [...seq].sort((a, b) => a - b), `CT_SlideLayout child order violated: ${seq.join(',')}`)
+
+	assert.ok(/<p:ph\s+idx="\d+"\s+type="title"\s+orient="vert"\s+sz="half"\s+hasCustomPrompt="1"/.test(layout.replace(/\s+/g, ' ')), `p:ph wrong: ${/<p:ph[\s\S]*?\/>/.exec(layout)?.[0] ?? ''}`)
+	assert.ok(layout.includes('<p:nvPr userDrawn="1">'), 'p:nvPr@userDrawn missing')
+
+	let plain = ''
+	for (const file of zip.file(/ppt\/slideLayouts\/slideLayout\d+\.xml/) ?? []) {
+		const xml = await file.async('string')
+		if (xml.includes('name="PLAIN"')) plain = xml
+	}
+	assert.ok(plain, 'no PLAIN layout')
+	assert.ok(!/<p:sldLayout[^>]*preserve=/.test(plain), 'preserve:false was ignored')
+
+	const bare = new pptxgen()
+	bare.defineSlideMaster({ title: 'BARE', objects: [{ placeholder: { options: { name: 'b', type: 'body', x: 1, y: 1, w: 6, h: 1 } } }] })
+	bare.addSlide({ masterName: 'BARE' })
+	const bareZip = await writeZip(bare)
+	for (const file of bareZip.file(/ppt\/slideLayouts\/slideLayout\d+\.xml/) ?? []) {
+		const xml = await file.async('string')
+		if (!xml.includes('name="BARE"') && !xml.includes('name="DEFAULT"')) continue
+		const tag = /<p:sldLayout[^>]*>/.exec(xml)?.[0] ?? ''
+		assert.ok(tag.includes('preserve="1"'), `${file.name} lost preserve="1"`)
+		for (const attr of ['type=', 'matchingName=', 'showMasterSp=', 'showMasterPhAnim=', 'userDrawn=']) {
+			assert.ok(!tag.includes(attr), `${file.name} gained ${attr}`)
+		}
+		assert.ok(xml.includes('<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>'), `${file.name} lost the inherited colour mapping`)
+		assert.ok(!xml.includes('orient=') && !xml.includes(' sz="half"') && !xml.includes('userDrawn='), `${file.name} gained placeholder metadata`)
+	}
+})


### PR DESCRIPTION
## Summary
- Port opt-in presentation/view/document properties from Neoma `ac6ebed8`: `photoAlbum`, `kinsoku`, `slideSizeType`, `documentProps`, `viewProps`. `printProps` / `recentColors` emit on `presentationPr` (ECMA-376 `CT_PresentationProperties`), not `presentation.xml`.
- Port slide-layout and placeholder metadata from `7ab09b1c`: `layoutType`, `matchingName`, `showMasterShapes`, `preserve`, colour-map override, per-layout transition, plus `p:ph@orient` / `@sz` / `@hasCustomPrompt` and `p:nvPr@userDrawn`. Existing placeholder inherit is unchanged.
- Port editing locks and non-visual props from `64352c44`: `lock` (`spLocks` / `picLocks` / `grpSpLocks` / `cxnSpLocks` / `graphicFrameLocks`) and `cNvPr@title` / `@hidden` on shapes, groups, images, tables, and connectors.
- Port `UnitLength` (`in` / `cm` / `mm` / `pt`) onto `Coord` from `66885cd0`. Bare numbers stay inches.

## Skipped
- `modifyVerifier` and `webPr` — listed as gaps but not present in the four scoped Neoma commits.
- Neoma autoPage deprecation.
- `prnPr` / `clrMru` placement in `presentation.xml` (Neoma) — moved to `presProps.xml` so the default and opt-in packages stay schema-valid.

## Test plan
- [x] `bun test test/gen-utils.test.ts test/contracts.test.ts test/issues.test.ts` (239 pass)
- [ ] Default export still opens in PowerPoint with no extra presentation/view/layout attributes
- [ ] Opt-in `viewProps` / `documentProps` / layout metadata / locks / unit-suffixed coords round-trip in PowerPoint

Made with [Cursor](https://cursor.com)