### PR TITLE
feat: complete DrawingML color, line, and text primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Image `recolor` (`ImageRecolorProps`) for duotone, grayscale, brightness/contrast, bi-level, and color-change on `a:blip` (does not replace SVG `fill` path recolor)
 - Shape/image `styleRef` emits `p:style` (`lnRef`/`fillRef`/`effectRef`/`fontRef`) so theme swaps can restyle objects
 - `slide.addConnector(options)` convenience that maps onto the existing connector fields, with optional `start`/`end` `objectName` glue
+- DrawingML colors accept object forms (`{ hex }`, `{ scheme }`, `{ system }`, `{ preset }`, `{ hsl }`, `{ scrgb }`) in addition to hex strings, theme tokens, and `ModifiedThemeColor`; scheme slots now include `dk1`/`lt1`/`hlink`/`folHlink`/`phClr`
+- Lines emit the rest of `CT_LineProperties`: `compound`, `join`/`miterLimit`, `custDash`, and `beginArrowSize`/`endArrowSize`
+- Text emits remaining `a:bodyPr`/`a:pPr`/`a:rPr` attributes (`upright`, `textRotate`, `anchorCtr`, paragraph line-break flags, `underlineLine`, `fontFaceSym`, …)
 - Text `vertOverflow` / `horzOverflow` emit ECMA-376 `a:bodyPr` overflow attrs so overflowing runs can clip instead of spilling out of the shape
 - Package-contract tests for opt-in `addFont` (Font parts, `application/x-fontdata`, Presentation font rels); default export embeds nothing
 - `pptx.slideShow` emits a spec-valid `p:showPr` with the required present/browse/kiosk choice, plus loop/narration/animation/timing flags

--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -54,7 +54,65 @@ export type WRITE_OUTPUT_TYPE = JSZIP_OUTPUT_TYPE | 'STREAM'
 export type CHART_NAME = 'area' | 'bar' | 'bar3D' | 'bubble' | 'bubble3D' | 'doughnut' | 'line' | 'pie' | 'radar' | 'scatter'
 /** PowerPoint 2016+ chart types; emitted as a `cx:chartSpace` part (MS-ODRAWXML 2.1) rather than ECMA-376 `c:chartSpace` */
 export type CHARTEX_NAME = 'boxWhisker' | 'funnel' | 'histogram' | 'sunburst' | 'treemap' | 'waterfall'
-export type SCHEME_COLORS = 'tx1' | 'tx2' | 'bg1' | 'bg2' | 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
+export type SCHEME_COLORS =
+	| 'tx1' | 'tx2' | 'bg1' | 'bg2'
+	| 'dk1' | 'lt1' | 'dk2' | 'lt2'
+	| 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
+	| 'hlink' | 'folHlink' | 'phClr'
+
+/** ECMA-376 20.1.10.51 ST_SchemeColorVal - every slot `a:schemeClr@val` accepts */
+export const SCHEME_COLOR_VALUES = new Set<string>([
+	'bg1', 'tx1', 'bg2', 'tx2', 'dk1', 'lt1', 'dk2', 'lt2',
+	'accent1', 'accent2', 'accent3', 'accent4', 'accent5', 'accent6',
+	'hlink', 'folHlink', 'phClr',
+])
+
+/** ECMA-376 20.1.10.58 ST_SystemColorVal - `a:sysClr@val` */
+export const SYSTEM_COLOR_VALUES = new Set([
+	'scrollBar', 'background', 'activeCaption', 'inactiveCaption', 'menu', 'window', 'windowFrame',
+	'menuText', 'windowText', 'captionText', 'activeBorder', 'inactiveBorder', 'appWorkspace',
+	'highlight', 'highlightText', 'btnFace', 'btnShadow', 'grayText', 'btnText',
+	'inactiveCaptionText', 'btnHighlight', '3dDkShadow', '3dLight', 'infoText', 'infoBk',
+	'hotLight', 'gradientActiveCaption', 'gradientInactiveCaption', 'menuHighlight', 'menuBar',
+])
+
+/** ECMA-376 20.1.10.48 ST_PresetColorVal - the 140 named preset colors for `a:prstClr@val` */
+export const PRESET_COLOR_VALUES = new Set([
+	'aliceBlue', 'antiqueWhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black',
+	'blanchedAlmond', 'blue', 'blueViolet', 'brown', 'burlyWood', 'cadetBlue', 'chartreuse',
+	'chocolate', 'coral', 'cornflowerBlue', 'cornsilk', 'crimson', 'cyan', 'darkBlue', 'darkCyan',
+	'darkGoldenrod', 'darkGray', 'darkGrey', 'darkGreen', 'darkKhaki', 'darkMagenta',
+	'darkOliveGreen', 'darkOrange', 'darkOrchid', 'darkRed', 'darkSalmon', 'darkSeaGreen',
+	'darkSlateBlue', 'darkSlateGray', 'darkSlateGrey', 'darkTurquoise', 'darkViolet', 'deepPink',
+	'deepSkyBlue', 'dimGray', 'dimGrey', 'dkBlue', 'dkCyan', 'dkGoldenrod', 'dkGray', 'dkGrey',
+	'dkGreen', 'dkKhaki', 'dkMagenta', 'dkOliveGreen', 'dkOrange', 'dkOrchid', 'dkRed', 'dkSalmon',
+	'dkSeaGreen', 'dkSlateBlue', 'dkSlateGray', 'dkSlateGrey', 'dkTurquoise', 'dkViolet',
+	'dodgerBlue', 'firebrick', 'floralWhite', 'forestGreen', 'fuchsia', 'gainsboro', 'ghostWhite',
+	'gold', 'goldenrod', 'gray', 'grey', 'green', 'greenYellow', 'honeydew', 'hotPink',
+	'indianRed', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderBlush', 'lawnGreen',
+	'lemonChiffon', 'lightBlue', 'lightCoral', 'lightCyan', 'lightGoldenrodYellow', 'lightGray',
+	'lightGrey', 'lightGreen', 'lightPink', 'lightSalmon', 'lightSeaGreen', 'lightSkyBlue',
+	'lightSlateGray', 'lightSlateGrey', 'lightSteelBlue', 'lightYellow', 'lime', 'limeGreen',
+	'linen', 'ltBlue', 'ltCoral', 'ltCyan', 'ltGoldenrodYellow', 'ltGray', 'ltGrey', 'ltGreen',
+	'ltPink', 'ltSalmon', 'ltSeaGreen', 'ltSkyBlue', 'ltSlateGray', 'ltSlateGrey', 'ltSteelBlue',
+	'ltYellow', 'magenta', 'maroon', 'medAquamarine', 'medBlue', 'medOrchid', 'medPurple',
+	'medSeaGreen', 'medSlateBlue', 'medSpringGreen', 'medTurquoise', 'medVioletRed',
+	'mediumAquamarine', 'mediumBlue', 'mediumOrchid', 'mediumPurple', 'mediumSeaGreen',
+	'mediumSlateBlue', 'mediumSpringGreen', 'mediumTurquoise', 'mediumVioletRed', 'midnightBlue',
+	'mintCream', 'mistyRose', 'moccasin', 'navajoWhite', 'navy', 'oldLace', 'olive', 'oliveDrab',
+	'orange', 'orangeRed', 'orchid', 'paleGoldenrod', 'paleGreen', 'paleTurquoise',
+	'paleVioletRed', 'papayaWhip', 'peachPuff', 'peru', 'pink', 'plum', 'powderBlue', 'purple',
+	'red', 'rosyBrown', 'royalBlue', 'saddleBrown', 'salmon', 'sandyBrown', 'seaGreen', 'seaShell',
+	'sienna', 'silver', 'skyBlue', 'slateBlue', 'slateGray', 'slateGrey', 'snow', 'springGreen',
+	'steelBlue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white',
+	'whiteSmoke', 'yellow', 'yellowGreen',
+])
+
+/** ECMA-376 20.1.10.23 ST_CompoundLine - `a:ln@cmpd` */
+export const COMPOUND_TYPES = new Set(['sng', 'dbl', 'thickThin', 'thinThick', 'tri'])
+
+/** ECMA-376 20.1.10.34/35 ST_LineEndWidth and ST_LineEndLength - arrow sizing */
+export const ARROW_SIZES = new Set(['sm', 'med', 'lg'])
 
 /**
  * Chart style and chart colour-style parts (MS-ODRAWXML)
@@ -478,6 +536,13 @@ export enum SchemeColor {
 	'accent4' = 'accent4',
 	'accent5' = 'accent5',
 	'accent6' = 'accent6',
+	'dk1' = 'dk1',
+	'lt1' = 'lt1',
+	'dk2' = 'dk2',
+	'lt2' = 'lt2',
+	'hlink' = 'hlink',
+	'folHlink' = 'folHlink',
+	'phClr' = 'phClr',
 }
 export enum AlignH {
 	'left' = 'left',

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -109,12 +109,79 @@ export interface BackgroundProps extends DataOrPathProps, ShapeFillProps {
  * @example 'FF3399'
  */
 export type HexColor = string
-export type ThemeColor = 'tx1' | 'tx2' | 'bg1' | 'bg2' | 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
+export type ThemeColor =
+	| 'tx1' | 'tx2' | 'bg1' | 'bg2'
+	| 'dk1' | 'lt1' | 'dk2' | 'lt2'
+	| 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
+	| 'hlink' | 'folHlink' | 'phClr'
+/** Every `a:schemeClr@val` slot (ECMA-376 20.1.10.51 ST_SchemeColorVal) */
+export type SchemeColorValue = ThemeColor
 /**
- * Color value: hex RGB, scheme token, or a scheme/hex color with OOXML transforms
- * (selective port of rafalBujok/define_color_theme + allow_modified_color_theme)
+ * Color value: hex RGB, scheme token, `ModifiedThemeColor`, or a DrawingML color object
+ * (`{ hex }`, `{ scheme }`, `{ system }`, `{ preset }`, `{ hsl }`, `{ scrgb }`)
  */
-export type Color = HexColor | ThemeColor | ModifiedThemeColor
+export type Color = HexColor | ThemeColor | ModifiedThemeColor | ColorProps
+/**
+ * Color transforms on a `ColorProps` object (ECMA-376 20.1.2.3, `EG_ColorTransform`)
+ * - `tint`/`shade`/`alpha` are 0-100; `*Off` are -100-100; `*Mod` are unbounded scales
+ * - `hueOff` is in degrees
+ */
+export interface ColorTransformProps {
+	/** lighten toward white (percent) */
+	tint?: number
+	/** darken toward black (percent) */
+	shade?: number
+	/** opacity (percent); 100 is opaque */
+	alpha?: number
+	/** shift opacity (percent, -100 to 100) */
+	alphaOff?: number
+	/** scale opacity (percent) */
+	alphaMod?: number
+	/** scale luminance (percent) */
+	lumMod?: number
+	/** shift luminance (percent, -100 to 100) */
+	lumOff?: number
+	/** scale saturation (percent) */
+	satMod?: number
+	/** shift saturation (percent, -100 to 100) */
+	satOff?: number
+	/** scale hue (percent) */
+	hueMod?: number
+	/** shift hue (degrees, -360 to 360) */
+	hueOff?: number
+	/** use the complement */
+	complement?: boolean
+	/** use the inverse */
+	inverse?: boolean
+	/** convert to grayscale */
+	grayscale?: boolean
+	/** apply gamma */
+	gamma?: boolean
+	/** apply inverse gamma */
+	inverseGamma?: boolean
+}
+/**
+ * A color given as an object so the non-hex DrawingML color kinds are reachable
+ * - exactly one specification field identifies the color; that is what distinguishes a color
+ *   object from a fill object at runtime
+ * @example { hex: 'FF0000', alpha: 50 }
+ * @example { scheme: 'accent1', lumMod: 60, lumOff: 40 }
+ * @example { preset: 'cornflowerBlue' }
+ * @example { hsl: { hue: 210, sat: 80, lum: 50 }, shade: 25 }
+ */
+export type ColorProps =
+	/** 6-digit hex (`a:srgbClr`) */
+	| ({ hex: HexColor } & ColorTransformProps)
+	/** theme slot (`a:schemeClr`) */
+	| ({ scheme: SchemeColorValue } & ColorTransformProps)
+	/** system color such as `windowText`, with an optional last-known value (`a:sysClr`) */
+	| ({ system: string, lastColor?: HexColor } & ColorTransformProps)
+	/** one of the 140 preset color names (`a:prstClr`) */
+	| ({ preset: string } & ColorTransformProps)
+	/** hue/saturation/luminance; hue in degrees, the rest percent (`a:hslClr`) */
+	| ({ hsl: { hue: number, sat: number, lum: number } } & ColorTransformProps)
+	/** linear-gamma RGB percentages (`a:scrgbClr`) */
+	| ({ scrgb: { r: number, g: number, b: number } } & ColorTransformProps)
 export type Margin = number | [number, number, number, number]
 export type HAlign = 'left' | 'center' | 'right' | 'justify'
 export type VAlign = 'top' | 'middle' | 'bottom'
@@ -878,6 +945,8 @@ export interface ShapeGradientProps {
 	 */
 	stops: ShapeGradientStopProps[]
 }
+/** ECMA-376 ST_LineEndWidth / ST_LineEndLength */
+export type LineArrowSize = 'sm' | 'med' | 'lg'
 export interface ShapeLineProps extends ShapeFillProps {
 	/**
 	 * Line width (pt)
@@ -936,8 +1005,36 @@ export interface ShapeLineProps extends ShapeFillProps {
 	_sourceName?: string
 	/** `objectName` of the end shape (resolved to `targetId` at emit) @internal */
 	_targetName?: string
-	// FUTURE: beginArrowSize (1-9)
-	// FUTURE: endArrowSize (1-9)
+	/**
+	 * Compound line type (`a:ln@cmpd`)
+	 * @default 'sng'
+	 */
+	compound?: 'sng' | 'dbl' | 'thickThin' | 'thinThick' | 'tri'
+	/**
+	 * How line segments join at a corner (`a:round` / `a:bevel` / `a:miter`)
+	 */
+	join?: 'round' | 'bevel' | 'miter'
+	/**
+	 * `join: 'miter'` only: how far the miter may extend, as a percent of line width (`a:miter@lim`)
+	 * @default 800
+	 */
+	miterLimit?: number
+	/**
+	 * Custom dash pattern (`a:custDash`), overriding `dashType`
+	 * - each stop is a dash length and the gap after it, as a percent of line width
+	 * @example [{ dash: 400, space: 300 }, { dash: 100, space: 300 }]
+	 */
+	custDash?: Array<{ dash: number, space: number }>
+	/**
+	 * Arrow head size (`a:headEnd@w` / `@len`)
+	 * - `beginArrowType` selects the shape; this sizes it
+	 * - a string applies to both width and length
+	 */
+	beginArrowSize?: LineArrowSize | { width?: LineArrowSize, length?: LineArrowSize }
+	/**
+	 * Arrow tail size (`a:tailEnd@w` / `@len`)
+	 */
+	endArrowSize?: LineArrowSize | { width?: LineArrowSize, length?: LineArrowSize }
 
 	/**
 	 * Dash type
@@ -1112,6 +1209,11 @@ export interface TextBaseProps {
 	 * @example 'Arial'
 	 */
 	fontFaceCs?: string
+	/**
+	 * Symbol typeface (`a:sym`), for Wingdings-style glyphs
+	 * @example 'Wingdings'
+	 */
+	fontFaceSym?: string
 	/**
 	 * Gradient text fill (`a:gradFill` on `a:rPr`). When set, overrides solid `color`.
 	 * @example { type:'linear', angle:45, stops:[{ pos:0, color:'FF0000' }, { pos:100, color:'0000FF' }] }
@@ -2421,7 +2523,106 @@ export type TextFieldType =
 	| 'datetime8' | 'datetime9' | 'datetime10' | 'datetime11' | 'datetime12' | 'datetime13'
 	| 'headerfooter' | 'hdr' | 'ftr'
 
-export interface TextPropsOptions extends PositionProps, DataOrPathProps, TextBaseProps, ObjectNameProps, AppearOnClickProps, NvPrExtensionProps {
+/**
+ * Text-body attributes beyond wrap/insets/anchor (`a:bodyPr`, ECMA-376 21.1.2.1.1)
+ * - omitted unless set, so default output does not change
+ * - overflow uses the existing `vertOverflow` / `horzOverflow` options
+ */
+export interface TextBodyProps {
+	/**
+	 * Keep text upright when the shape is rotated (`a:bodyPr@upright`)
+	 * @default false
+	 */
+	upright?: boolean
+	/**
+	 * Rotate the text body independently of the shape, in degrees (`a:bodyPr@rot`)
+	 * - distinct from the shape's own `rotate`
+	 */
+	textRotate?: number
+	/**
+	 * Center the anchor point as well as the text (`a:bodyPr@anchorCtr`)
+	 * @default false
+	 */
+	anchorCtr?: boolean
+	/**
+	 * Respect paragraph spacing before the first and after the last line (`a:bodyPr@spcFirstLastPara`)
+	 * @default false
+	 */
+	spcFirstLastPara?: boolean
+	/**
+	 * Use legacy line-spacing rules (`a:bodyPr@compatLnSpc`)
+	 * @default false
+	 */
+	compatLnSpc?: boolean
+	/**
+	 * Force anti-aliasing regardless of size (`a:bodyPr@forceAA`)
+	 * @default false
+	 */
+	forceAA?: boolean
+}
+/**
+ * Paragraph attributes beyond margins/alignment (`a:pPr`, ECMA-376 21.1.2.2.7)
+ */
+export interface ParagraphProps {
+	/**
+	 * Right margin in inches (`a:pPr@marR`)
+	 */
+	marR?: number
+	/**
+	 * Default tab stop interval in inches (`a:pPr@defTabSz`)
+	 */
+	defTabSz?: number
+	/**
+	 * Baseline alignment of glyphs within the line (`a:pPr@fontAlgn`)
+	 */
+	fontAlgn?: 'auto' | 't' | 'ctr' | 'base' | 'b'
+	/**
+	 * Apply East Asian line-breaking rules (`a:pPr@eaLnBrk`)
+	 * - schema default is true; written only when turned off
+	 * @default true
+	 */
+	eaLnBrk?: boolean
+	/**
+	 * Allow Latin words to break across lines (`a:pPr@latinLnBrk`)
+	 * - schema default is true; written only when turned off
+	 * @default true
+	 */
+	latinLnBrk?: boolean
+	/**
+	 * Apply hanging punctuation (`a:pPr@hangingPunct`)
+	 * - schema default is true; written only when turned off
+	 * @default true
+	 */
+	hangingPunct?: boolean
+}
+/**
+ * Run attributes beyond bold/italic/size (`a:rPr`, ECMA-376 21.1.2.3.9)
+ * - `caps` lives on `TextPropsOptions` (already present)
+ */
+export interface TextRunProps {
+	/**
+	 * Normalise glyph heights (`a:rPr@normalizeH`)
+	 * @default false
+	 */
+	normalizeH?: boolean
+	/**
+	 * Exclude the run from spelling and grammar checking (`a:rPr@noProof`)
+	 * @default false
+	 */
+	noProof?: boolean
+	/**
+	 * Mark the run as needing re-inspection (`a:rPr@dirty`)
+	 * - previously hardcoded to `0`
+	 * @default false
+	 */
+	dirty?: boolean
+	/**
+	 * Underline line properties (`a:uLn`), distinct from the underline colour
+	 * - pass `'text'` to follow the run's own line (`a:uLnTx`)
+	 */
+	underlineLine?: 'text' | ShapeLineProps
+}
+export interface TextPropsOptions extends PositionProps, DataOrPathProps, TextBaseProps, ObjectNameProps, AppearOnClickProps, NvPrExtensionProps, TextBodyProps, ParagraphProps, TextRunProps {
 	_bodyProp?: {
 		// Note: Many of these duplicated as user options are transformed to _bodyProp options for XML processing
 		autoFit?: boolean

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -1361,6 +1361,7 @@ export function addShapeDefinition(target: PresSlide | SlideLayout, shapeName: S
 	// 1: ShapeLineProps defaults
 	const hasConnectorEnds = options.line.sourceId != null || options.line.targetId != null
 	const newLineOpts: ShapeLineProps = {
+		...options.line,
 		type: options.line.type || (options.line.gradient ? 'gradient' : 'solid'),
 		color: options.line.color || DEF_SHAPE_LINE_COLOR,
 		transparency: options.line.transparency || 0,
@@ -1753,6 +1754,7 @@ export function addTextDefinition(target: PresSlide | SlideLayout, text: TextPro
 			if (itemOpts.shape === SHAPE_TYPE.LINE) {
 				// ShapeLineProps defaults
 				const newLineOpts: ShapeLineProps = {
+					...itemOpts.line,
 					type: itemOpts.line?.type || (itemOpts.line?.gradient ? 'gradient' : 'solid'),
 					color: itemOpts.line?.color || DEF_SHAPE_LINE_COLOR,
 					transparency: itemOpts.line?.transparency || 0,

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -798,8 +798,8 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 				)
 				break
 			case 'image': {
-				const image = typeof props === 'string' || isModifiedThemeColor(props) ? undefined : props.image
-				const rId = image?._rId ?? (typeof props === 'string' || isModifiedThemeColor(props) ? undefined : props._rId)
+				const image = isBareColor ? undefined : props.image
+				const rId = image?._rId ?? (isBareColor ? undefined : props._rId)
 				if (rId) {
 					outText += createImageFillElement(image ?? {}, rId)
 				} else {

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -4,8 +4,8 @@
 
 import { parseXml } from '@rgrove/parse-xml'
 
-import { EMU, REGEX_HEX_COLOR, DEF_FONT_COLOR, DEF_TEXT_GLOW, ONEPT, SchemeColor, SCHEME_COLORS, TILE_ALIGNMENTS } from './core-enums'
-import { PresLayout, TextGlowProps, PresSlide, SlideLayout, ShapeFillProps, Color, ShapeLineProps, Coord, ShadowProps, ShapeGradientProps, ShapePatternProps, ShapeImageFillProps, ModifiedThemeColor, ThemeProps, HexColor } from './core-interfaces'
+import { DEF_FONT_COLOR, DEF_TEXT_GLOW, EMU, ONEPT, PRESET_COLOR_VALUES, REGEX_HEX_COLOR, SCHEME_COLORS, SCHEME_COLOR_VALUES, SYSTEM_COLOR_VALUES, TILE_ALIGNMENTS } from './core-enums'
+import { Color, ColorProps, ColorTransformProps, Coord, HexColor, ModifiedThemeColor, PresLayout, PresSlide, ShadowProps, ShapeFillProps, ShapeGradientProps, ShapeImageFillProps, ShapeLineProps, ShapePatternProps, SlideLayout, TextGlowProps, ThemeProps } from './core-interfaces'
 
 /** debug namespace, used for both the log prefix and the `NODE_DEBUG` section name */
 const DEBUG_NS = 'pptxgenjs'
@@ -425,6 +425,15 @@ export function isModifiedThemeColor (value: unknown): value is ModifiedThemeCol
 	return typeof value === 'object' && value !== null && 'baseColor' in value
 }
 
+/**
+ * Whether a value is a DrawingML color object rather than a fill object
+ * - the six specification fields are unique to `ColorProps`
+ */
+export function isColorProps (value: unknown): value is ColorProps {
+	if (!value || typeof value !== 'object') return false
+	return ['hex', 'scheme', 'system', 'preset', 'hsl', 'scrgb'].some(key => key in value)
+}
+
 /** Percent-based OOXML color transforms (0-100 → val*1000) */
 const PERCENT_COLOR_MODIFIERS = [
 	'alpha', 'alphaMod', 'alphaOff',
@@ -478,12 +487,96 @@ function handleModifiedColorProps (color: ModifiedThemeColor): string {
  * Thi sis wrong. We s/b calling `genXmlColorSelection()` instead as it returns `<a:solidfill>BLAH</a:solidFill>`!!
  */
 /**
+ * DrawingML stores percentages in 1000ths of a percent
+ * - `CT_PositiveFixedPercentage` (tint, shade, alpha) is 0-100
+ * - `CT_FixedPercentage` (the `*Off` transforms) is -100 to 100
+ * - `CT_PositivePercentage` (the `*Mod` transforms) is a *scale* and is unbounded above
+ */
+function pct (value: number, min = 0, max = 100): string {
+	const clamped = Math.min(max, Math.max(min, isFinite(value) ? value : 0))
+	return String(Math.round(clamped * 1000))
+}
+
+/**
+ * Create the color transform children shared by every ColorProps element (ECMA-376 20.1.2.3)
+ */
+function createColorTransforms (props: ColorTransformProps): string {
+	let xml = ''
+
+	if (typeof props.tint === 'number') xml += `<a:tint val="${pct(props.tint)}"/>`
+	if (typeof props.shade === 'number') xml += `<a:shade val="${pct(props.shade)}"/>`
+	if (props.inverse === true) xml += '<a:inv/>'
+	if (props.grayscale === true) xml += '<a:gray/>'
+	if (typeof props.alpha === 'number') xml += `<a:alpha val="${pct(props.alpha)}"/>`
+	if (typeof props.alphaOff === 'number') xml += `<a:alphaOff val="${pct(props.alphaOff, -100, 100)}"/>`
+	if (typeof props.alphaMod === 'number') xml += `<a:alphaMod val="${pct(props.alphaMod, 0, Number.MAX_SAFE_INTEGER)}"/>`
+	if (typeof props.hueMod === 'number') xml += `<a:hueMod val="${pct(props.hueMod, 0, Number.MAX_SAFE_INTEGER)}"/>`
+	if (typeof props.hueOff === 'number') xml += `<a:hueOff val="${Math.round(Math.min(360, Math.max(-360, isFinite(props.hueOff) ? props.hueOff : 0)) * 60000)}"/>`
+	if (typeof props.satMod === 'number') xml += `<a:satMod val="${pct(props.satMod, 0, Number.MAX_SAFE_INTEGER)}"/>`
+	if (typeof props.satOff === 'number') xml += `<a:satOff val="${pct(props.satOff, -100, 100)}"/>`
+	if (typeof props.lumMod === 'number') xml += `<a:lumMod val="${pct(props.lumMod, 0, Number.MAX_SAFE_INTEGER)}"/>`
+	if (typeof props.lumOff === 'number') xml += `<a:lumOff val="${pct(props.lumOff, -100, 100)}"/>`
+	if (props.complement === true) xml += '<a:comp/>'
+	if (props.gamma === true) xml += '<a:gamma/>'
+	if (props.inverseGamma === true) xml += '<a:invGamma/>'
+
+	return xml
+}
+
+/**
+ * Create the color element for a `ColorProps` object
+ */
+function createColorPropsElement (props: ColorProps, extra: string): string {
+	const inner = createColorTransforms(props) + extra
+	const wrap = (tag: string, attrs: string): string => (inner ? `<a:${tag} ${attrs}>${inner}</a:${tag}>` : `<a:${tag} ${attrs}/>`)
+
+	if ('hex' in props) {
+		const hex = String(props.hex ?? '').replace('#', '')
+		if (!REGEX_HEX_COLOR.test(hex)) {
+			console.warn(`[pptxgenjs] "${hex}" is not a 6-digit hex color - "${DEF_FONT_COLOR}" used instead`)
+			return wrap('srgbClr', `val="${DEF_FONT_COLOR}"`)
+		}
+		return wrap('srgbClr', `val="${hex.toUpperCase()}"`)
+	}
+	if ('scheme' in props) {
+		if (!SCHEME_COLOR_VALUES.has(props.scheme)) {
+			console.warn(`[pptxgenjs] "${String(props.scheme)}" is not a theme color slot - "${DEF_FONT_COLOR}" used instead`)
+			return wrap('srgbClr', `val="${DEF_FONT_COLOR}"`)
+		}
+		return wrap('schemeClr', `val="${props.scheme}"`)
+	}
+	if ('system' in props) {
+		if (!SYSTEM_COLOR_VALUES.has(props.system)) {
+			console.warn(`[pptxgenjs] "${String(props.system)}" is not a system color - "${DEF_FONT_COLOR}" used instead`)
+			return wrap('srgbClr', `val="${DEF_FONT_COLOR}"`)
+		}
+		const last = props.lastColor && REGEX_HEX_COLOR.test(props.lastColor.replace('#', '')) ? ` lastClr="${props.lastColor.replace('#', '').toUpperCase()}"` : ''
+		return wrap('sysClr', `val="${props.system}"${last}`)
+	}
+	if ('preset' in props) {
+		if (!PRESET_COLOR_VALUES.has(props.preset)) {
+			console.warn(`[pptxgenjs] "${String(props.preset)}" is not a preset color name - "${DEF_FONT_COLOR}" used instead`)
+			return wrap('srgbClr', `val="${DEF_FONT_COLOR}"`)
+		}
+		return wrap('prstClr', `val="${props.preset}"`)
+	}
+	if ('hsl' in props) {
+		const hue = Math.round(((((props.hsl.hue % 360) + 360) % 360) || 0) * 60000)
+		return wrap('hslClr', `hue="${isFinite(hue) ? hue : 0}" sat="${pct(props.hsl.sat)}" lum="${pct(props.hsl.lum)}"`)
+	}
+	return wrap('scrgbClr', `r="${pct(props.scrgb.r)}" g="${pct(props.scrgb.g)}" b="${pct(props.scrgb.b)}"`)
+}
+
+/**
  * Create either a `a:schemeClr` - (scheme color) or `a:srgbClr` (hexa representation).
- * @param {Color|SCHEME_COLORS} colorInput - hex, scheme token, or ModifiedThemeColor
+ * Object forms (`ColorProps`, `ModifiedThemeColor`) reach the rest of the DrawingML color model.
+ * @param {Color|SCHEME_COLORS} colorInput - hex, scheme token, ModifiedThemeColor, or ColorProps
  * @param {string} innerElements - additional elements that adjust the color and are enclosed by the color element
  * @returns {string} XML string
  */
 export function createColorElement (colorInput: Color | SCHEME_COLORS | undefined, innerElements?: string): string {
+	if (isColorProps(colorInput)) return createColorPropsElement(colorInput, innerElements ?? '')
+
 	const base = isModifiedThemeColor(colorInput) ? colorInput.baseColor : colorInput
 	const colorStr = typeof base === 'string' ? base : DEF_FONT_COLOR
 	let colorVal = (colorStr || '').replace('#', '')
@@ -493,19 +586,7 @@ export function createColorElement (colorInput: Color | SCHEME_COLORS | undefine
 		kids += handleModifiedColorProps(colorInput)
 	}
 
-	if (
-		!REGEX_HEX_COLOR.test(colorVal) &&
-		colorVal !== SchemeColor.background1 &&
-		colorVal !== SchemeColor.background2 &&
-		colorVal !== SchemeColor.text1 &&
-		colorVal !== SchemeColor.text2 &&
-		colorVal !== SchemeColor.accent1 &&
-		colorVal !== SchemeColor.accent2 &&
-		colorVal !== SchemeColor.accent3 &&
-		colorVal !== SchemeColor.accent4 &&
-		colorVal !== SchemeColor.accent5 &&
-		colorVal !== SchemeColor.accent6
-	) {
+	if (!REGEX_HEX_COLOR.test(colorVal) && !SCHEME_COLOR_VALUES.has(colorVal)) {
 		console.warn(`"${colorVal}" is not a valid scheme color or hex RGB! "${DEF_FONT_COLOR}" used instead. Only provide 6-digit RGB or 'pptx.SchemeColor' values!`)
 		colorVal = DEF_FONT_COLOR
 	}
@@ -680,10 +761,10 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 	let outText = ''
 
 	if (props) {
-		// ModifiedThemeColor as a bare Color value (must not be treated as ShapeFillProps)
+		// A bare color - string, ModifiedThemeColor, or ColorProps - is a solid fill of that color
 		if (typeof props === 'string') {
 			colorVal = props
-		} else if (isModifiedThemeColor(props)) {
+		} else if (isModifiedThemeColor(props) || isColorProps(props)) {
 			colorVal = props
 		} else {
 			if (props.type) fillType = props.type
@@ -693,6 +774,7 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 			if (props.transparency) internalElements += `<a:alpha val="${Math.round((100 - props.transparency) * 1000)}"/>`
 		}
 
+		const isBareColor = typeof props === 'string' || isModifiedThemeColor(props) || isColorProps(props)
 		switch (fillType) {
 			case 'solid':
 				outText += `<a:solidFill>${createColorElement(colorVal, internalElements)}</a:solidFill>`
@@ -700,15 +782,19 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 			case 'gradient':
 			case 'linearGradient':
 				outText += createGradientFillElement(
-					typeof props === 'string' || isModifiedThemeColor(props) ? undefined : resolveGradientProps(props),
+					isBareColor ? undefined : resolveGradientProps(props),
 					colorVal || '',
 					internalElements,
 				)
 				break
 			case 'pattern':
 				outText += createPatternFillElement(
-					typeof props === 'string' || isModifiedThemeColor(props) ? undefined : props.pattern,
-					typeof colorVal === 'string' ? colorVal : String(colorVal.baseColor),
+					isBareColor ? undefined : props.pattern,
+					typeof colorVal === 'string'
+						? colorVal
+						: isModifiedThemeColor(colorVal)
+							? String(colorVal.baseColor)
+							: DEF_FONT_COLOR,
 				)
 				break
 			case 'image': {

--- a/src/xml/index.ts
+++ b/src/xml/index.ts
@@ -1,5 +1,6 @@
 export * from './content-parts'
 export * from './hyperlink'
+export * from './line'
 export * from './package'
 export * from './relationships'
 export * from './slide'

--- a/src/xml/line.ts
+++ b/src/xml/line.ts
@@ -1,0 +1,85 @@
+/**
+ * PptxGenJS: Line properties (`a:ln` and its aliases)
+ *
+ * The same `CT_LineProperties` content model is used by shape outlines (`a:ln`), underlines
+ * (`a:uLn`), and table cell borders, so the element name is a parameter rather than baked in.
+ */
+
+import { ARROW_SIZES, COMPOUND_TYPES } from '../core-enums'
+import { LineArrowSize, ShapeLineProps } from '../core-interfaces'
+import { genXmlColorSelection, valToPts } from '../gen-utils'
+
+/**
+ * Create a line element
+ * @param {ShapeLineProps} line - line options
+ * @param {string} tag - element name; `a:ln` for a shape outline, `a:uLn` for an underline
+ * @return {string} XML
+ */
+export function genXmlLine (line: ShapeLineProps, tag = 'a:ln'): string {
+	// ECMA-376 §5.1.2.1.34: `<a:ln>` carries `w`, `cap`, and `cmpd` attributes
+	const cap = line.cap && ['flat', 'sq', 'rnd'].includes(line.cap) ? ` cap="${line.cap}"` : ''
+	const compound = COMPOUND_TYPES.has(String(line.compound)) ? ` cmpd="${String(line.compound)}"` : ''
+	if (line.compound && !COMPOUND_TYPES.has(String(line.compound))) {
+		console.warn(`[pptxgenjs] line \`compound\` must be one of ${[...COMPOUND_TYPES].join(', ')} - "${String(line.compound)}" ignored`)
+	}
+
+	const attrs = (line.width ? ` w="${valToPts(line.width)}"` : '') + cap + compound
+	let xml = `<${tag}${attrs}>`
+	const hasGrad = !!(line.gradient || line.type === 'gradient' || line.type === 'linearGradient')
+	if (line.type !== 'none' && (line.color || hasGrad)) {
+		xml += genXmlColorSelection(hasGrad && !line.type ? { ...line, type: 'gradient' } : line)
+	}
+
+	// CT_LineProperties sequence: fill, dash, join, headEnd, tailEnd. A custom pattern replaces
+	// the preset one - emitting both would be ambiguous, since `a:custDash` is the same choice.
+	xml += genXmlDash(line)
+	xml += genXmlJoin(line)
+	xml += genXmlArrow('a:headEnd', line.beginArrowType, line.beginArrowSize)
+	xml += genXmlArrow('a:tailEnd', line.endArrowType, line.endArrowSize)
+
+	xml += `</${tag}>`
+	return xml
+}
+
+/** The dash choice: a custom pattern when given, otherwise the preset */
+function genXmlDash (line: ShapeLineProps): string {
+	const stops = (line.custDash ?? []).filter(stop => {
+		const ok = typeof stop?.dash === 'number' && isFinite(stop.dash) && stop.dash > 0 &&
+			typeof stop.space === 'number' && isFinite(stop.space) && stop.space >= 0
+		if (!ok) console.warn('[pptxgenjs] each `custDash` stop needs a positive `dash` and a non-negative `space` (percent of line width) - stop ignored')
+		return ok
+	})
+	if (stops.length > 0) {
+		const items = stops.map(stop => `<a:ds d="${Math.round(stop.dash * 1000)}" sp="${Math.round(stop.space * 1000)}"/>`).join('')
+		return `<a:custDash>${items}</a:custDash>`
+	}
+	return line.dashType ? `<a:prstDash val="${line.dashType}"/>` : ''
+}
+
+/** The join choice: `a:round`, `a:bevel`, or `a:miter` with its limit */
+function genXmlJoin (line: ShapeLineProps): string {
+	if (!line.join) return ''
+	if (line.join === 'round') return '<a:round/>'
+	if (line.join === 'bevel') return '<a:bevel/>'
+	if (line.join === 'miter') {
+		const lim = typeof line.miterLimit === 'number' && isFinite(line.miterLimit) && line.miterLimit >= 0 ? line.miterLimit : 800
+		return `<a:miter lim="${Math.round(lim * 1000)}"/>`
+	}
+	console.warn(`[pptxgenjs] line \`join\` must be 'round' | 'bevel' | 'miter' - "${String(line.join)}" ignored`)
+	return ''
+}
+
+function resolveArrowSize (size?: LineArrowSize | { width?: LineArrowSize, length?: LineArrowSize }): { width?: string, length?: string } | undefined {
+	if (!size) return undefined
+	if (typeof size === 'string') return { width: size, length: size }
+	return size
+}
+
+/** An arrow end with its optional sizing */
+function genXmlArrow (tag: string, type?: string, size?: LineArrowSize | { width?: LineArrowSize, length?: LineArrowSize }): string {
+	if (!type) return ''
+	const resolved = resolveArrowSize(size)
+	const w = ARROW_SIZES.has(String(resolved?.width)) ? ` w="${String(resolved?.width)}"` : ''
+	const len = ARROW_SIZES.has(String(resolved?.length)) ? ` len="${String(resolved?.length)}"` : ''
+	return `<${tag} type="${type}"${w}${len}/>`
+}

--- a/src/xml/package.ts
+++ b/src/xml/package.ts
@@ -29,7 +29,8 @@ import { AUTHOR_PART_CONTENT_TYPE, AUTHOR_REL_TYPE, COMMENT_PART_CONTENT_TYPE, C
 import { createColorElement, encodeXmlEntities, genXmlColorSelection, getUuid, inch2Emu, resolveThemeColors } from '../gen-utils'
 import { extPartPackagePath } from './content-parts'
 import { slideCommentsRelId } from './relationships'
-import { genXmlLine, resolveZoomSections, slideObjectToXml } from './slide'
+import { genXmlLine } from './line'
+import { resolveZoomSections, slideObjectToXml } from './slide'
 import { A14_NS, genXmlDesignTagLst, MATH_NS, MC_NS, P14_NS, P1710_NS, URI_DESIGN_TAG_LST } from './text'
 import {
 	CHANGES_INFO_CONTENT_TYPE,

--- a/src/xml/slide.ts
+++ b/src/xml/slide.ts
@@ -58,6 +58,7 @@ import { getImagePixelSize } from '../gen-media'
 import { genXmlCreationIdExt, genXmlModIdExt, TABLE_MOD_ID_BASE } from '../gen-revision'
 import { genXmlContentPartAlternate, genXmlOfficeAppAlternate } from './content-parts'
 import { genXmlHyperlink } from './hyperlink'
+import { genXmlLine } from './line'
 import { genXmlCNvPr, genXmlCNvSpPr, genXmlLocks } from './non-visual'
 import { MC_NS, genXmlNvPrExtLst, genXmlPlaceholder, genXmlTextBody, textRunsHaveOmml } from './text'
 
@@ -218,27 +219,6 @@ function genXmlAudioCdTime (tag: string, point?: AudioCdTimeProps): string {
 	const track = Math.min(255, Math.max(0, Math.round(point?.track ?? 0)))
 	const time = typeof point?.time === 'number' && isFinite(point.time) && point.time > 0 ? ` time="${Math.round(point.time)}"` : ''
 	return `<${tag} track="${track}"${time}/>`
-}
-
-/**
- * Create the `a:ln` outline block for a shape/image
- * @param {ShapeLineProps} line - line options
- * @return {string} XML
- */
-export function genXmlLine (line: ShapeLineProps): string {
-	// ECMA-376 §5.1.2.1.34: `<a:ln>` carries `w` and `cap` attributes (cap = line ending style, issue #782)
-	const attrs = (line.width ? ` w="${valToPts(line.width)}"` : '') + (line.cap && ['flat', 'sq', 'rnd'].includes(line.cap) ? ` cap="${line.cap}"` : '')
-	let xml = `<a:ln${attrs}>`
-	const hasGrad = !!(line.gradient || line.type === 'gradient' || line.type === 'linearGradient')
-	if (line.type !== 'none' && (line.color || hasGrad)) {
-		xml += genXmlColorSelection(hasGrad && !line.type ? { ...line, type: 'gradient' } : line)
-	}
-	if (line.dashType) xml += `<a:prstDash val="${line.dashType}"/>`
-	if (line.beginArrowType) xml += `<a:headEnd type="${line.beginArrowType}"/>`
-	if (line.endArrowType) xml += `<a:tailEnd type="${line.endArrowType}"/>`
-	// FUTURE: `endArrowSize` < a: headEnd type = "arrow" w = "lg" len = "lg" /> 'sm' | 'med' | 'lg'(values are 1 - 9, making a 3x3 grid of w / len possibilities)
-	xml += '</a:ln>'
-	return xml
 }
 
 /**

--- a/src/xml/text.ts
+++ b/src/xml/text.ts
@@ -17,8 +17,11 @@ import {
 	ISlideObject,
 	ObjectOptions,
 	TableCell,
+	ParagraphProps,
+	TextBodyProps,
 	TextProps,
 	TextPropsOptions,
+	TextRunProps,
 	TextShapeType,
 } from '../core-interfaces'
 import { genXmlHyperlink } from './hyperlink'
@@ -37,6 +40,7 @@ const TEXT_SHAPE_TYPES: ReadonlySet<TextShapeType> = new Set([
 	'textSlantUp', 'textSlantDown', 'textCascadeUp', 'textCascadeDown',
 ])
 import {
+	convertRotationDegrees,
 	createColorElement,
 	createGlowElement,
 	encodeXmlEntities,
@@ -47,6 +51,7 @@ import {
 	valToPts,
 	warnDeprecatedOnce,
 } from '../gen-utils'
+import { genXmlLine } from './line'
 
 /**
  * Build the `a:buClr` / `a:buSzPct` / `a:buSzPts` / `a:buFont` prefix shared by every bullet kind
@@ -121,6 +126,16 @@ function genXmlParagraphProperties (textObj: ISlideObject | TextProps, isDefault
 		if (options.indentLevel && !isNaN(Number(options.indentLevel)) && options.indentLevel > 0) {
 			paragraphPropXml += ` lvl="${options.indentLevel}"`
 		}
+
+		// Remaining CT_TextParagraphProperties attributes - omitted unless set
+		const para = options as ParagraphProps
+		if (typeof para.marR === 'number' && isFinite(para.marR) && para.marR >= 0) paragraphPropXml += ` marR="${inch2Emu(para.marR)}"`
+		if (typeof para.defTabSz === 'number' && isFinite(para.defTabSz) && para.defTabSz > 0) paragraphPropXml += ` defTabSz="${inch2Emu(para.defTabSz)}"`
+		if (['auto', 't', 'ctr', 'base', 'b'].includes(String(para.fontAlgn))) paragraphPropXml += ` fontAlgn="${String(para.fontAlgn)}"`
+		// these three default to true in the schema, so only write them when turned off
+		if (para.eaLnBrk === false) paragraphPropXml += ' eaLnBrk="0"'
+		if (para.latinLnBrk === false) paragraphPropXml += ' latinLnBrk="0"'
+		if (para.hangingPunct === false) paragraphPropXml += ' hangingPunct="0"'
 
 		// OPTION: Paragraph Spacing: Before/After
 		if (options.paraSpaceBefore && !isNaN(Number(options.paraSpaceBefore)) && options.paraSpaceBefore > 0) {
@@ -239,9 +254,13 @@ function genXmlTextRunProperties (opts: ObjectOptions | TextPropsOptions, isDefa
 	// ECMA-376 §5.1.12.64 ST_TextCapsType: render-only capitalization (issue #1312)
 	runProps += opts.caps && ['none', 'small', 'all'].includes(opts.caps) ? ` cap="${opts.caps}"` : ''
 	if (opts.kumimoji === true) runProps += ' kumimoji="1"'
-	runProps += ' dirty="0">'
-	// Color / Font / Highlight / Outline are children of <a:rPr>, so add them now before closing the runProperties tag
-	if (opts.color || opts.gradient || opts.fontFace || opts.fontFaceEa || opts.fontFaceCs || opts.outline || (typeof opts.underline === 'object' && opts.underline.color)) {
+	const run = opts as TextRunProps
+	if (run.normalizeH === true) runProps += ' normalizeH="1"'
+	if (run.noProof === true) runProps += ' noProof="1"'
+	// `dirty` was hardcoded to 0; it stays the default so existing output does not change
+	runProps += ` dirty="${run.dirty === true ? '1' : '0'}">`
+	// CT_TextCharacterProperties child order: ln, fill, effect, highlight, uLn, uFill, latin, ea, cs, sym
+	if (opts.color || opts.gradient || opts.fontFace || opts.fontFaceEa || opts.fontFaceCs || opts.fontFaceSym || opts.outline || opts.glow || opts.highlight || run.underlineLine || (typeof opts.underline === 'object' && opts.underline.color)) {
 		if (opts.outline && typeof opts.outline === 'object') {
 			runProps += `<a:ln w="${valToPts(opts.outline.size || 0.75)}">${genXmlColorSelection({
 				color: opts.outline.color || 'FFFFFF',
@@ -251,10 +270,12 @@ function genXmlTextRunProperties (opts: ObjectOptions | TextPropsOptions, isDefa
 		// Run fill: gradient (`a:gradFill`) takes precedence over solid `color` (WordArt / text gradient)
 		if (opts.gradient) runProps += genXmlColorSelection({ type: 'gradient', gradient: opts.gradient, transparency: opts.transparency })
 		else if (opts.color) runProps += genXmlColorSelection({ color: opts.color, transparency: opts.transparency })
-		if (opts.highlight) runProps += `<a:highlight>${createColorElement(opts.highlight)}</a:highlight>`
-		if (typeof opts.underline === 'object' && opts.underline.color) runProps += `<a:uFill>${genXmlColorSelection(opts.underline.color)}</a:uFill>`
 		const resolvedGlow = resolveGlowOptions(opts.glow)
 		if (resolvedGlow) runProps += `<a:effectLst>${createGlowElement(resolvedGlow)}</a:effectLst>`
+		if (opts.highlight) runProps += `<a:highlight>${createColorElement(opts.highlight)}</a:highlight>`
+		if (run.underlineLine === 'text') runProps += '<a:uLnTx/>'
+		else if (run.underlineLine && typeof run.underlineLine === 'object') runProps += genXmlLine(run.underlineLine, 'a:uLn')
+		if (typeof opts.underline === 'object' && opts.underline.color) runProps += `<a:uFill>${genXmlColorSelection(opts.underline.color)}</a:uFill>`
 		const latin = opts.fontFace
 		const ea = opts.fontFaceEa || opts.fontFace
 		const cs = opts.fontFaceCs || opts.fontFace
@@ -264,6 +285,7 @@ function genXmlTextRunProperties (opts: ObjectOptions | TextPropsOptions, isDefa
 			if (ea) runProps += `<a:ea typeface="${encodeXmlEntities(ea)}" pitchFamily="34" charset="-122"/>`
 			if (cs) runProps += `<a:cs typeface="${encodeXmlEntities(cs)}" pitchFamily="34" charset="-120"/>`
 		}
+		if (opts.fontFaceSym) runProps += `<a:sym typeface="${encodeXmlEntities(opts.fontFaceSym)}"/>`
 	}
 
 	// Hyperlink support
@@ -427,6 +449,15 @@ function genXmlBodyProperties (slideObject: ISlideObject | TableCell): string {
 		if (slideObject.options._bodyProp.tIns || slideObject.options._bodyProp.tIns === 0) bodyProperties += ` tIns="${slideObject.options._bodyProp.tIns}"`
 		if (slideObject.options._bodyProp.rIns || slideObject.options._bodyProp.rIns === 0) bodyProperties += ` rIns="${slideObject.options._bodyProp.rIns}"`
 		if (slideObject.options._bodyProp.bIns || slideObject.options._bodyProp.bIns === 0) bodyProperties += ` bIns="${slideObject.options._bodyProp.bIns}"`
+
+		// Remaining CT_TextBodyProperties attributes - each omitted unless asked for
+		const body = slideObject.options as TextBodyProps
+		if (body.upright === true) bodyProperties += ' upright="1"'
+		if (typeof body.textRotate === 'number' && isFinite(body.textRotate)) bodyProperties += ` rot="${convertRotationDegrees(body.textRotate)}"`
+		if (body.anchorCtr === true) bodyProperties += ' anchorCtr="1"'
+		if (body.spcFirstLastPara === true) bodyProperties += ' spcFirstLastPara="1"'
+		if (body.compatLnSpc === true) bodyProperties += ' compatLnSpc="1"'
+		if (body.forceAA === true) bodyProperties += ' forceAA="1"'
 
 		// Text columns — ECMA-376 §5.1.5.1.4 CT_TextBodyProperties@numCol/@spcCol (issue #1320)
 		if (slideObject.options._bodyProp.numCol && slideObject.options._bodyProp.numCol > 1) {

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -781,3 +781,95 @@ test('contract: objects without locks keep the output they always had', async ()
 	assert.match(xml, /<p:cNvPicPr><a:picLocks noChangeAspect="1"\/><\/p:cNvPicPr>/, 'default picture lock changed')
 	assert.match(xml, /<a:graphicFrameLocks noGrp="1"\/>/, 'default frame lock changed')
 })
+
+test('contract: the remaining a:bodyPr, a:pPr, and a:rPr attributes are reachable', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addText('all the attributes', {
+		x: 1, y: 1, w: 4, h: 2,
+		upright: true, textRotate: 15, anchorCtr: true, spcFirstLastPara: true,
+		compatLnSpc: true, forceAA: true,
+		marR: 0.25, defTabSz: 0.5, fontAlgn: 'ctr',
+		eaLnBrk: false, latinLnBrk: false, hangingPunct: false,
+		caps: 'small', normalizeH: true, noProof: true, dirty: true,
+		fontFace: 'Georgia', fontFaceEa: 'MS Gothic', fontFaceCs: 'Arial', fontFaceSym: 'Wingdings',
+		underlineLine: { width: 1.5, color: 'FF0000', dashType: 'dash' },
+	})
+	const attrZip = await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer)
+	await assertPptxPackageContracts(attrZip)
+	const xml = await readPart(attrZip, 'ppt/slides/slide1.xml')
+
+	assert.doesNotMatch(xml, /NaN|undefined/, 'attributes must not leak invalid values')
+	assert.match(xml, /<a:bodyPr wrap="square" upright="1" rot="900000" anchorCtr="1" spcFirstLastPara="1" compatLnSpc="1" forceAA="1"/, 'bodyPr attributes missing')
+	assert.match(xml, /<a:pPr marR="228600" defTabSz="457200" fontAlgn="ctr" eaLnBrk="0" latinLnBrk="0" hangingPunct="0"/, 'pPr attributes missing')
+	assert.match(xml, /<a:rPr lang="en-US" cap="small" normalizeH="1" noProof="1" dirty="1">/, 'rPr attributes missing')
+	assert.match(xml, /<a:latin typeface="Georgia"[^>]*\/><a:ea typeface="MS Gothic"[^>]*\/><a:cs typeface="Arial"[^>]*\/><a:sym typeface="Wingdings"\/>/, 'per-script fonts or sym missing')
+	assert.match(xml, /<a:uLn w="19050"><a:solidFill><a:srgbClr val="FF0000"\/><\/a:solidFill><a:prstDash val="dash"\/><\/a:uLn>/, 'uLn missing')
+})
+
+test('contract: rPr children follow the schema sequence', async () => {
+	const pptx = new pptxgen()
+	pptx.addSlide().addText([{
+		text: 'ordered',
+		options: {
+			outline: { size: 1, color: '000000' },
+			color: 'FF0000',
+			// glow on the run itself (shape-level glow lives on effectLst, issue #84)
+			glow: { size: 4, color: 'FFFF00', opacity: 0.5 },
+			highlight: '00FF00',
+			underline: { style: 'sng', color: '0000FF' },
+			underlineLine: 'text',
+			fontFace: 'Arial',
+			fontFaceSym: 'Wingdings',
+		},
+	}], { x: 1, y: 1, w: 4, h: 1 })
+	const xml = await readPart(await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer), 'ppt/slides/slide1.xml')
+
+	const order = ['a:ln', 'a:solidFill', 'a:effectLst', 'a:highlight', 'a:uLnTx', 'a:uFill', 'a:latin', 'a:ea', 'a:cs', 'a:sym']
+	const rPr = /<a:rPr[^>]*>[\s\S]*?<\/a:rPr>/.exec(xml)?.[0] ?? ''
+	assert.ok(rPr, 'rPr not found')
+	const positions = order.map(tag => ({ tag, at: rPr.indexOf(`<${tag}`) }))
+	positions.forEach(entry => { assert.ok(entry.at > -1, `${entry.tag} missing from rPr`) })
+	positions.reduce((prev, entry) => {
+		assert.ok(entry.at > prev.at, `${entry.tag} must follow ${prev.tag} in CT_TextCharacterProperties`)
+		return entry
+	})
+})
+
+test('contract: text without the new attributes is unchanged', async () => {
+	const pptx = new pptxgen()
+	pptx.addSlide().addText('plain', { x: 1, y: 1, w: 3, h: 1 })
+	const xml = await readPart(await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer), 'ppt/slides/slide1.xml')
+
+	assert.match(xml, /<a:bodyPr wrap="square" rtlCol="0" anchor="ctr">/, 'default bodyPr changed')
+	assert.match(xml, /<a:rPr lang="en-US" dirty="0">/, 'default rPr changed - `dirty` must stay 0')
+	assert.doesNotMatch(xml, /upright|rot=|anchorCtr|spcFirstLastPara|compatLnSpc|forceAA/, 'no new bodyPr attribute may appear unasked')
+	assert.doesNotMatch(xml, /marR=|defTabSz=|fontAlgn=|eaLnBrk=|latinLnBrk=|hangingPunct=/, 'no pPr attribute may appear unasked')
+	assert.doesNotMatch(xml, /cap=|normalizeH|noProof|a:uLn|a:sym/, 'no rPr attribute may appear unasked')
+})
+
+test('contract: line compound, join, custDash, and arrow size reach a:ln', async () => {
+	const pptx = new pptxgen()
+	pptx.addSlide().addShape(pptx.ShapeType.line, {
+		x: 1, y: 1, w: 3, h: 0,
+		line: {
+			color: '000000',
+			width: 2,
+			compound: 'dbl',
+			join: 'miter',
+			miterLimit: 400,
+			custDash: [{ dash: 200, space: 100 }],
+			beginArrowType: 'arrow',
+			beginArrowSize: { width: 'lg', length: 'sm' },
+			endArrowType: 'triangle',
+			endArrowSize: 'med',
+		},
+	})
+	const xml = await readPart(await JSZip.loadAsync((await pptx.write({ outputType: 'nodebuffer' })) as Buffer), 'ppt/slides/slide1.xml')
+	assert.match(xml, /<a:ln w="25400" cmpd="dbl">/, 'compound missing')
+	assert.match(xml, /<a:custDash><a:ds d="200000" sp="100000"\/><\/a:custDash>/, 'custDash missing')
+	assert.match(xml, /<a:miter lim="400000"\/>/, 'miter join missing')
+	assert.match(xml, /<a:headEnd type="arrow" w="lg" len="sm"\/>/, 'beginArrowSize missing')
+	assert.match(xml, /<a:tailEnd type="triangle" w="med" len="med"\/>/, 'endArrowSize string form missing')
+	assert.doesNotMatch(xml, /<a:prstDash/, 'custDash must replace prstDash')
+})

--- a/test/gen-utils.test.ts
+++ b/test/gen-utils.test.ts
@@ -35,6 +35,8 @@ import {
 	utf8ToBase64,
 } from '../src/gen-utils'
 import { PresLayout, PresSlide, ShadowProps } from '../src/core-interfaces'
+import { DEF_FONT_COLOR } from '../src/core-enums'
+import { genXmlLine } from '../src/xml/line'
 
 // 10in x 7.5in layout expressed in EMU
 const LAYOUT = { name: 'TEST', width: 9144000, height: 6858000 } as PresLayout
@@ -424,6 +426,118 @@ function listBrowserSrcFiles (dir: string): string[] {
 	}
 	return out
 }
+
+test('createColorElement: ColorProps object forms', () => {
+	assert.equal(createColorElement({ hex: 'FF0000' }), '<a:srgbClr val="FF0000"/>')
+	assert.equal(createColorElement({ scheme: 'accent1' }), '<a:schemeClr val="accent1"/>')
+	assert.equal(createColorElement({ scheme: 'hlink' }), '<a:schemeClr val="hlink"/>')
+	assert.equal(createColorElement({ scheme: 'folHlink' }), '<a:schemeClr val="folHlink"/>')
+	assert.equal(createColorElement({ scheme: 'phClr' }), '<a:schemeClr val="phClr"/>')
+	assert.equal(createColorElement({ scheme: 'dk1' }), '<a:schemeClr val="dk1"/>')
+	assert.equal(createColorElement({ system: 'windowText' }), '<a:sysClr val="windowText"/>')
+	assert.equal(createColorElement({ system: 'windowText', lastColor: '#000000' }), '<a:sysClr val="windowText" lastClr="000000"/>')
+	assert.equal(createColorElement({ preset: 'cornflowerBlue' }), '<a:prstClr val="cornflowerBlue"/>')
+	assert.equal(createColorElement({ hsl: { hue: 210, sat: 80, lum: 50 } }), '<a:hslClr hue="12600000" sat="80000" lum="50000"/>')
+	assert.equal(createColorElement({ scrgb: { r: 100, g: 50, b: 0 } }), '<a:scrgbClr r="100000" g="50000" b="0"/>')
+	// string form of the extra scheme slots
+	assert.equal(createColorElement('dk1'), '<a:schemeClr val="dk1"/>')
+	assert.equal(createColorElement('hlink'), '<a:schemeClr val="hlink"/>')
+})
+
+test('createColorElement: ColorProps transforms and their unit ranges', () => {
+	assert.equal(createColorElement({ hex: 'FF0000', alpha: 50 }), '<a:srgbClr val="FF0000"><a:alpha val="50000"/></a:srgbClr>')
+	assert.equal(createColorElement({ scheme: 'accent1', lumMod: 60, lumOff: 40 }), '<a:schemeClr val="accent1"><a:lumMod val="60000"/><a:lumOff val="40000"/></a:schemeClr>')
+	assert.equal(createColorElement({ scheme: 'accent1', satMod: 170 }), '<a:schemeClr val="accent1"><a:satMod val="170000"/></a:schemeClr>')
+	assert.equal(createColorElement({ hex: '00FF00', lumOff: -25, satOff: 200 }), '<a:srgbClr val="00FF00"><a:satOff val="100000"/><a:lumOff val="-25000"/></a:srgbClr>')
+	assert.equal(createColorElement({ hex: '00FF00', hueOff: -30 }), '<a:srgbClr val="00FF00"><a:hueOff val="-1800000"/></a:srgbClr>')
+	assert.equal(createColorElement({ hex: '00FF00', inverse: true, grayscale: true, complement: true, gamma: true, inverseGamma: true }),
+		'<a:srgbClr val="00FF00"><a:inv/><a:gray/><a:comp/><a:gamma/><a:invGamma/></a:srgbClr>')
+	assert.equal(createColorElement({ hex: '00FF00', alpha: 150, tint: -20 }), '<a:srgbClr val="00FF00"><a:tint val="0"/><a:alpha val="100000"/></a:srgbClr>')
+})
+
+test('createColorElement: unknown ColorProps names fall back rather than emit invalid enums', () => {
+	const orig = console.warn
+	const warnings: string[] = []
+	console.warn = (msg: string) => warnings.push(String(msg))
+	try {
+		assert.equal(createColorElement({ scheme: 'nope' as unknown as 'accent1' }), `<a:srgbClr val="${DEF_FONT_COLOR}"/>`)
+		assert.equal(createColorElement({ system: 'chartreuse' }), `<a:srgbClr val="${DEF_FONT_COLOR}"/>`)
+		assert.equal(createColorElement({ preset: 'ultraviolet' }), `<a:srgbClr val="${DEF_FONT_COLOR}"/>`)
+		assert.equal(createColorElement({ hex: 'ZZZ' }), `<a:srgbClr val="${DEF_FONT_COLOR}"/>`)
+		assert.equal(createColorElement({ system: 'windowText', lastColor: 'nope' }), '<a:sysClr val="windowText"/>')
+	} finally {
+		console.warn = orig
+	}
+	assert.equal(warnings.length, 4, 'each rejected name warns once')
+	assert.ok(warnings.some(w => w.includes('is not a theme color slot')))
+	assert.ok(warnings.some(w => w.includes('is not a system color')))
+	assert.ok(warnings.some(w => w.includes('is not a preset color name')))
+})
+
+test('createColorElement: ModifiedThemeColor still works beside ColorProps', () => {
+	assert.equal(
+		createColorElement({ baseColor: 'accent1', tint: 40 }),
+		'<a:schemeClr val="accent1"><a:tint val="40000"/></a:schemeClr>'
+	)
+})
+
+test('genXmlColorSelection: a color object is a solid fill, a fill object is not', () => {
+	assert.equal(genXmlColorSelection({ scheme: 'accent1', lumMod: 75 }), '<a:solidFill><a:schemeClr val="accent1"><a:lumMod val="75000"/></a:schemeClr></a:solidFill>')
+	assert.equal(genXmlColorSelection({ preset: 'gold' }), '<a:solidFill><a:prstClr val="gold"/></a:solidFill>')
+	assert.equal(genXmlColorSelection({ type: 'solid', color: 'FF0000' }), '<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>')
+	assert.equal(genXmlColorSelection({ type: 'solid', color: { scheme: 'accent2', shade: 50 } }), '<a:solidFill><a:schemeClr val="accent2"><a:shade val="50000"/></a:schemeClr></a:solidFill>')
+	assert.equal(genXmlColorSelection({ baseColor: 'accent1', tint: 25 }), '<a:solidFill><a:schemeClr val="accent1"><a:tint val="25000"/></a:schemeClr></a:solidFill>')
+})
+
+test('genXmlLine: preset dash, cap, compound, joins, and arrow sizing', () => {
+	assert.equal(genXmlLine({ width: 2, color: 'FF0000', dashType: 'dash' }),
+		'<a:ln w="25400"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:prstDash val="dash"/></a:ln>')
+	assert.equal(genXmlLine({ width: 2, color: 'FF0000', cap: 'rnd' }),
+		'<a:ln w="25400" cap="rnd"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln>')
+	assert.equal(genXmlLine({ width: 3, color: '000000', compound: 'thickThin' }),
+		'<a:ln w="38100" cmpd="thickThin"><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:ln>')
+	assert.equal(genXmlLine({ color: '000000', join: 'round' }), '<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:round/></a:ln>')
+	assert.equal(genXmlLine({ color: '000000', join: 'bevel' }), '<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:bevel/></a:ln>')
+	assert.equal(genXmlLine({ color: '000000', join: 'miter', miterLimit: 400 }), '<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:miter lim="400000"/></a:ln>')
+	assert.equal(genXmlLine({ color: '000000', join: 'miter' }), '<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:miter lim="800000"/></a:ln>')
+	assert.equal(genXmlLine({ color: '000000', beginArrowType: 'arrow', beginArrowSize: { width: 'lg', length: 'lg' }, endArrowType: 'triangle', endArrowSize: { width: 'sm' } }),
+		'<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:headEnd type="arrow" w="lg" len="lg"/><a:tailEnd type="triangle" w="sm"/></a:ln>')
+	assert.equal(genXmlLine({ color: '000000', beginArrowType: 'arrow', beginArrowSize: 'med' }),
+		'<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:headEnd type="arrow" w="med" len="med"/></a:ln>')
+})
+
+test('genXmlLine: a custom dash replaces the preset one', () => {
+	assert.equal(genXmlLine({ color: '000000', dashType: 'dash', custDash: [{ dash: 400, space: 300 }, { dash: 100, space: 300 }] }),
+		'<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:custDash><a:ds d="400000" sp="300000"/><a:ds d="100000" sp="300000"/></a:custDash></a:ln>')
+})
+
+test('genXmlLine: the same content model serves a:uLn', () => {
+	assert.equal(genXmlLine({ width: 1, color: 'FF0000', dashType: 'solid' }, 'a:uLn'),
+		'<a:uLn w="12700"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:prstDash val="solid"/></a:uLn>')
+})
+
+test('genXmlLine: invalid line options are dropped with a warning', () => {
+	const orig = console.warn
+	const warnings: string[] = []
+	console.warn = (msg: string) => warnings.push(String(msg))
+	let compound = ''
+	let dash = ''
+	let join = ''
+	try {
+		compound = genXmlLine({ color: '000000', compound: 'quad' as 'sng' })
+		dash = genXmlLine({ color: '000000', custDash: [{ dash: -1, space: 100 }, { dash: 200, space: 100 }] })
+		join = genXmlLine({ color: '000000', join: 'sharp' as 'miter' })
+	} finally {
+		console.warn = orig
+	}
+	assert.ok(warnings.some(w => w.includes('`compound` must be one of')), 'bad compound must warn')
+	assert.ok(warnings.some(w => w.includes('each `custDash` stop needs')), 'bad dash stop must warn')
+	assert.ok(warnings.some(w => w.includes('`join` must be')), 'bad join must warn')
+	assert.doesNotMatch(compound, /cmpd=/, 'an invalid compound must not be emitted')
+	assert.match(dash, /<a:custDash><a:ds d="200000" sp="100000"\/><\/a:custDash>/, 'valid dash stops must survive')
+	assert.doesNotMatch(join, /a:round|a:bevel|a:miter/, 'an invalid join must not be emitted')
+	assert.doesNotMatch(compound + dash + join, /NaN/, 'no NaN attributes')
+})
 
 test('browser-bundled helpers do not reference Buffer', () => {
 	const root = join(dirname(fileURLToPath(import.meta.url)), '..')

--- a/test/gen-utils.test.ts
+++ b/test/gen-utils.test.ts
@@ -520,9 +520,9 @@ test('genXmlLine: invalid line options are dropped with a warning', () => {
 	const orig = console.warn
 	const warnings: string[] = []
 	console.warn = (msg: string) => warnings.push(String(msg))
-	let compound = ''
-	let dash = ''
-	let join = ''
+	let compound: string
+	let dash: string
+	let join: string
 	try {
 		compound = genXmlLine({ color: '000000', compound: 'quad' as 'sng' })
 		dash = genXmlLine({ color: '000000', custDash: [{ dash: -1, space: 100 }, { dash: 200, space: 100 }] })


### PR DESCRIPTION
## Summary
- Extend `Color` additively with Neoma object forms (`{ hex }`, `{ scheme }`, `{ system }`, `{ preset }`, `{ hsl }`, `{ scrgb }`) while keeping hex strings, theme tokens, and `ModifiedThemeColor`.
- Finish `a:ln` (`compound`, `join`/`miterLimit`, `custDash`, `beginArrowSize`/`endArrowSize`) via new `src/xml/line.ts`, reused for `a:uLn`.
- Emit remaining `a:bodyPr` / `a:pPr` / `a:rPr` attributes and fix `a:rPr` child order (effect before highlight/uLn).

## Skipped
- `fb8e7fb5` types-parity / missing effect props: this fork already declares `ReflectionProps`, `SoftEdgeProps`, and `glow` on images/shapes, and generates `types/index.d.ts`.
- Already present: theme colors, `ModifiedThemeColor` transforms, line width/dash/cap/arrows/connectors, text columns, overflow, `fontFaceEa`/`fontFaceCs`, `caps`, underline, tab stops.

## Test plan
- [x] `bun test test/gen-utils.test.ts test/contracts.test.ts`
- [x] `bun run typecheck`
- [ ] Open a generated deck in PowerPoint and check custom dash, arrow sizes, scheme/system/preset/hsl colors, and the new text attributes
