### PR TITLE
fix: unique p:cNvPr/@id for table+shape slides

### DIFF
--- a/src/xml/slide.ts
+++ b/src/xml/slide.ts
@@ -624,7 +624,6 @@ export function resolveZoomSections (slide: PresSlide, sections?: SectionProps[]
 
 export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 	let strSlideXml: string = slide._name ? `<p:cSld name="${encodeXmlEntities(slide._name)}">` : '<p:cSld>'
-	let intTableNum = 1
 
 	// STEP 1: Add background color/image (ensure only a single `<p:bg>` tag is created, ex: when master-baskground has both `color` and `path`)
 	if (slide._bkgdImgRid) {
@@ -775,7 +774,8 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 
 					// STEP 1: Start Table XML
 					// NOTE: Non-numeric cNvPr id values will trigger "presentation needs repair" type warning in MS-PPT-2013
-					strXml = '<p:graphicFrame><p:nvGraphicFramePr>' + genXmlCNvPr(intTableNum * (slide._slideNum ?? 0) + 1, String(slideItemObj.options.objectName ?? ''), slideItemObj.options)
+					// Use the shared slide allocator — `intTableNum * slideNum + 1` collided with `idx + 2` (gitbrent/PptxGenJS#1532)
+					strXml = '<p:graphicFrame><p:nvGraphicFramePr>' + genXmlCNvPr(shapeId, String(slideItemObj.options.objectName ?? ''), slideItemObj.options)
 					// When the table binds to a master/layout placeholder, emit `<p:ph type="tbl"/>` (ECMA-376 §4.4.1.33, issue #856)
 					const tblPh = placeholderObj ? genXmlPlaceholder(placeholderObj, slideItemObj.options) : ''
 					// MS-PPTX §2.3.1.19: each p14:modId must be unique on the slide (not a constant).
@@ -1014,9 +1014,6 @@ export function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 
 					// STEP 6: Set table XML
 					strSlideXml += strXml
-
-					// LAST: Increment counter
-					intTableNum++
 					break
 				}
 

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -3387,6 +3387,38 @@ test('SCV-Soft/9f66206: slide-number cNvPr id does not collide', async () => {
 	assert.doesNotMatch(xml, /<p:cNvPr id="25" name="Slide Number Placeholder 0"/, 'slide number still hardcoded to id 25')
 })
 
+function extractCnvPrIds (xml: string): number[] {
+	return [...xml.matchAll(/<p:cNvPr\b[^>]*\bid="(\d+)"/g)].map(match => Number(match[1]))
+}
+
+function assertUniqueCnvPrIds (ids: number[], label: string): void {
+	assert.ok(ids.length >= 3, `${label}: expected nvGrpSpPr + objects, got [${ids.join(', ')}]`)
+	assert.equal(ids[0], 1, `${label}: p:nvGrpSpPr must keep id="1"`)
+	assert.equal(new Set(ids).size, ids.length, `${label}: duplicate p:cNvPr/@id [${ids.join(', ')}]`)
+}
+
+test('gitbrent/PptxGenJS#1532: table + text shapes get unique p:cNvPr/@id', async () => {
+	const pptx = new pptxgen()
+	const slide = pptx.addSlide()
+	slide.addText('A text box', { x: 0.5, y: 0.5, w: 4, h: 0.5 })
+	slide.addTable([[{ text: 'A' }, { text: 'B' }]], { x: 0.5, y: 1.5, w: 4 })
+
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide1.xml')
+	assertUniqueCnvPrIds(extractCnvPrIds(xml), 'slide1 text+table')
+})
+
+test('gitbrent/PptxGenJS#1532: later slides keep unique p:cNvPr/@id with mixed object order', async () => {
+	const pptx = new pptxgen()
+	pptx.addSlide()
+	const slide = pptx.addSlide()
+	slide.addTable([[{ text: 'A' }, { text: 'B' }]], { x: 0.5, y: 1.5, w: 4 })
+	slide.addText('A text box', { x: 0.5, y: 0.5, w: 4, h: 0.5 })
+	slide.addShape(pptx.ShapeType.rect, { x: 5, y: 0.5, w: 1, h: 1 })
+
+	const xml = await readPart(await writeZip(pptx), 'ppt/slides/slide2.xml')
+	assertUniqueCnvPrIds(extractCnvPrIds(xml), 'slide2 table+text+shape')
+})
+
 test('fujita-h/d7e3e93: explicit image x/y/w/h win over placeholder geometry', async () => {
 	const pptx = new pptxgen()
 	pptx.defineSlideMaster({


### PR DESCRIPTION
## Summary
- Port [gitbrent/PptxGenJS#1533](https://github.com/gitbrent/PptxGenJS/pull/1533) / [gitbrent/PptxGenJS#1532](https://github.com/gitbrent/PptxGenJS/issues/1532): tables now use the shared slide `cNvPr` allocator instead of `intTableNum * slideNum + 1`, which collided with other shapes (`idx + 2`).
- Add regression tests for text+table on slide 1 and mixed table/text/shape order on a later slide.

## Test plan
- [x] `bun test test/issues.test.ts --test-name-pattern "1532|slide-number cNvPr"`
- [ ] CI `bun run test` on this PR