### PR TITLE
fix: omit orphan chart series axis

### DIFF
--- a/src/charts/xml.ts
+++ b/src/charts/xml.ts
@@ -696,7 +696,8 @@ function makeChartType (
 			}
 
 			// 5: Add axisId (NOTE: order matters - category comes first)
-			strXml += `<c:axId val="${catAxisId}"/><c:axId val="${valAxisId}"/><c:axId val="${AXIS_ID_SERIES_PRIMARY}"/>`
+			strXml += `<c:axId val="${catAxisId}"/><c:axId val="${valAxisId}"/>`
+			if (chartType === CHART_TYPE.BAR3D) strXml += `<c:axId val="${AXIS_ID_SERIES_PRIMARY}"/>`
 
 			// 6: Close Chart tag
 			strXml += `</c:${chartType}Chart>`

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -41,6 +41,17 @@ async function readEmbeddedXlsx (zip: JSZip): Promise<JSZip> {
 	return await JSZip.loadAsync(await file.async('nodebuffer'))
 }
 
+test('#12: bar and line charts reference only their generated axes', async () => {
+	for (const type of ['bar', 'line', 'bar3D']) {
+		const pptx = new pptxgen()
+		pptx.addSlide().addChart(type, [{ name: 'Sales', labels: ['Q1', 'Q2'], values: [1, 2] }], { x: 1, y: 1, w: 4, h: 3 })
+		const xml = await readChart(await writeZip(pptx))
+		const plot = xml.match(new RegExp(`<c:${type}Chart>[\\s\\S]*?</c:${type}Chart>`))?.[0] ?? ''
+		assert.equal((plot.match(/<c:axId /g) ?? []).length, type === 'bar3D' ? 3 : 2)
+		assert.equal(xml.includes('<c:serAx>'), type === 'bar3D')
+	}
+})
+
 test('#19/#18: SVG image + hyperlink gets unique rIds and an escaped url', async () => {
 	const pptx = new pptxgen()
 	pptx.addSlide().addImage({ data: 'image/svg+xml;base64,PHN2Zy8+', x: 1, y: 1, w: 1, h: 1, hyperlink: { url: 'https://x.com/?a=1&b=2' } })


### PR DESCRIPTION
## Fix orphan chart axis references

2D bar and line charts emitted `AXIS_ID_SERIES_PRIMARY` even though no corresponding `<c:serAx>` was generated.

This produced an invalid dangling axis reference and caused PowerPoint to repair generated files.

### Changes
- Emit the series axis ID only for `bar3D`, where the series axis is actually generated.
- Add regression coverage for `bar`, `line`, and `bar3D` charts.

### Validation
- Targeted regression test passes.

### Issue https://github.com/lofcz/pptxgenjs-plus/issues/12